### PR TITLE
feat: add `sweep`

### DIFF
--- a/contracts/AaveStablecoinCellar.sol
+++ b/contracts/AaveStablecoinCellar.sol
@@ -45,8 +45,7 @@ contract AaveStablecoinCellar is
     address public immutable WETH; // 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
     address public immutable USDC; // 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
 
-    // Declare the variables and mappings
-    address[] public inputTokensList;
+    // Declare the variables and mappings.
     mapping(address => bool) internal inputTokens;
     // The address of the token of the current lending position
     address public currentLendingToken;
@@ -532,14 +531,11 @@ contract AaveStablecoinCellar is
     }
 
     /**
-     * @notice Approve a supported token to be deposited into the cellar.
+     * @notice Set approval for a token to be deposited into the cellar.
      * @param token the address of the supported token
-     */
-    function approveInputToken(address token) external onlyOwner {
-        if (inputTokens[token]) revert TokenAlreadyInitialized();
-
-        inputTokens[token] = true;
-        inputTokensList.push(token);
+     **/
+    function setInputToken(address token, bool isApproved) external onlyOwner {
+        inputTokens[token] = isApproved;
     }
 
     /// @notice Removes initial liquidity restriction.

--- a/contracts/interfaces/IAaveStablecoinCellar.sol
+++ b/contracts/interfaces/IAaveStablecoinCellar.sol
@@ -86,7 +86,6 @@ interface IAaveStablecoinCellar {
 
     error NonSupportedToken();
     error PathIsTooShort();
-    error TokenAlreadyInitialized();
     error ZeroAmount();
     error LiquidityRestricted();
 

--- a/tests/AaveStablecoinCellar.test.js
+++ b/tests/AaveStablecoinCellar.test.js
@@ -147,10 +147,10 @@ describe("AaveStablecoinCellar", () => {
     await usdt.mint(router.address, 5000);
 
     // Initialize with mock tokens as input tokens
-    await cellar.approveInputToken(usdc.address);
-    await cellar.approveInputToken(dai.address);
-    await cellar.approveInputToken(weth.address);
-    await cellar.approveInputToken(usdt.address);
+    await cellar.setInputToken(usdc.address, true);
+    await cellar.setInputToken(dai.address, true);
+    await cellar.setInputToken(weth.address, true);
+    await cellar.setInputToken(usdt.address, true);
   });
 
   describe("deposit", () => {


### PR DESCRIPTION
Functionality to removes tokens from this cellar that are not the type of token managed by this cellar. This may be used in case of accidentally sending the wrong kind of token to the cellar contract.