### PR TITLE
[audit]: audit fixes

### DIFF
--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -590,7 +590,8 @@ contract CellarStaking is ICellarStaking, Ownable {
 
         if (totalDeposits == 0 && endTimestamp == 0) {
             // No deposits yet, so keep rewards pending until first deposit
-            rewardsReady = reward;
+            // Incrementing in case it is called twice
+            rewardsReady += reward;
         } else {
             // Ready to start
             _startProgram(reward);

--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -588,7 +588,7 @@ contract CellarStaking is ICellarStaking, Ownable {
             revert USR_RewardTooLarge();
         }
 
-        if (totalDeposits == 0 && endTimestamp == 0) {
+        if (totalDeposits == 0) {
             // No deposits yet, so keep rewards pending until first deposit
             // Incrementing in case it is called twice
             rewardsReady += reward;

--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -8,8 +8,6 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import "./Errors.sol";
 import { ICellarStaking } from "./interfaces/ICellarStaking.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title Sommelier Staking
  * @author Kevin Kennis
@@ -548,7 +546,6 @@ contract CellarStaking is ICellarStaking, Ownable {
         }
 
         if (reward > 0) {
-            console.log("Reward:", reward);
             distributionToken.safeTransfer(msg.sender, reward);
 
             // No need for per-stake events like emergencyUnstake:
@@ -588,10 +585,7 @@ contract CellarStaking is ICellarStaking, Ownable {
             rewardsReady = reward;
         } else {
             // Ready to start
-            rewardRate = proposedRewardRate;
-            endTimestamp = block.timestamp + epochDuration;
-
-            emit Funding(reward, endTimestamp);
+            _startProgram(reward);
         }
     }
 
@@ -719,14 +713,11 @@ contract CellarStaking is ICellarStaking, Ownable {
      */
     function _startProgram(uint256 reward) internal {
         // Assumptions
-        // Total deposits are now not 0, no ongoing program
+        // Total deposits are now (mod current tx), no ongoing program
         // Rewards are already funded (since checked in notifyRewardAmount)
 
-        // Set new rate bc previous has already expired
         rewardRate = reward / epochDuration;
         endTimestamp = block.timestamp + epochDuration;
-
-        console.log("Started", rewardRate, epochDuration);
 
         emit Funding(reward, endTimestamp);
     }

--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -607,6 +607,8 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @param _epochDuration        The new duration for reward schedules.
      */
     function setRewardsDuration(uint256 _epochDuration) external override onlyOwner {
+        if (rewardsReady > 0) revert STATE_RewardsReady();
+
         nextEpochDuration = _epochDuration;
         emit EpochDurationChange(nextEpochDuration);
     }

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -160,6 +160,11 @@ error STATE_AlreadyShutdown();
 error STATE_RewardsNotFunded(uint256 rewardBalance, uint256 reward);
 
 /**
+ * @notice The caller attempted to change the next epoch duration, but there are rewards ready.
+ */
+ error STATE_RewardsReady();
+
+/**
  * @notice The caller attempted to change the epoch length, but current reward epochs were active.
  */
 error STATE_RewardsOngoing();

--- a/contracts/interfaces/ICellarStaking.sol
+++ b/contracts/interfaces/ICellarStaking.sol
@@ -46,7 +46,9 @@ interface ICellarStaking {
 
     function distributionToken() external returns (ERC20);
 
-    function epochDuration() external returns (uint256);
+    function currentEpochDuration() external returns (uint256);
+
+    function nextEpochDuration() external returns (uint256);
 
     function rewardsReady() external returns (uint256);
 

--- a/contracts/interfaces/ICellarStaking.sol
+++ b/contracts/interfaces/ICellarStaking.sol
@@ -48,6 +48,8 @@ interface ICellarStaking {
 
     function epochDuration() external returns (uint256);
 
+    function rewardsReady() external returns (uint256);
+
     function minimumDeposit() external returns (uint256);
 
     function endTimestamp() external returns (uint256);

--- a/tests/CellarStaking.test.ts
+++ b/tests/CellarStaking.test.ts
@@ -1410,6 +1410,16 @@ describe("CellarStaking", () => {
         expect(balanceBefore.sub(balanceAfter)).to.equal(rewards);
       });
 
+      it("should revert if the staking contract is not funded with enough tokens, counting an existing schedule", async () => {
+        // Call notify reward amount once
+        await stakingDist.notifyRewardAmount(initialTokenAmount);
+
+        // Schedule initialTokenAmount / 2 new rewards. Should fail because in total we need 3 * initialTokenAmount / 2 rewards
+        await expect(
+          stakingDist.notifyRewardAmount(initialTokenAmount.div(2))
+        ).to.be.revertedWith("STATE_RewardsNotFunded");
+      });
+
       it("should update and extend existing schedule", async () => {
         const { tokenDist, stakingUser } = ctx;
 

--- a/tests/CellarStaking.test.ts
+++ b/tests/CellarStaking.test.ts
@@ -1249,8 +1249,11 @@ describe("CellarStaking", () => {
         await expect(stakingUser.emergencyClaim()).to.be.revertedWith("STATE_NoEmergencyClaim");
       });
 
-      it("should allow rewards to be claimable", async () => {
+      it.only("should allow rewards to be claimable", async () => {
         const { staking, stakingUser, tokenDist, user } = ctx;
+
+        // Wait to ensure that depositor not immediately depositing
+        await increaseTime(oneWeekSec / 2);
 
         await stakingUser.stake(ether("10000"), lockTwoWeeks);
 
@@ -1277,7 +1280,7 @@ describe("CellarStaking", () => {
 
         expect(claimEvent).to.not.be.undefined;
         expect(claimEvent?.args?.[0]).to.equal(user.address);
-        expectRoundedEqual(claimEvent?.args?.[1], rewardPerEpoch);
+        expect(claimEvent?.args?.[1]).to.equal(rewardPerEpoch);
 
         const balanceAfter = await tokenDist.balanceOf(user.address);
 

--- a/tests/CellarStaking.test.ts
+++ b/tests/CellarStaking.test.ts
@@ -1523,13 +1523,15 @@ describe("CellarStaking", () => {
       it("should update the reward epoch duration", async () => {
         const { staking } = ctx;
 
-        expect(await staking.epochDuration()).to.equal(oneMonthSec);
+        const currentEpochDuration = await staking.currentEpochDuration();
+        expect(await staking.nextEpochDuration()).to.equal(oneMonthSec);
 
         await expect(staking.setRewardsDuration(oneWeekSec))
           .to.emit(staking, "EpochDurationChange")
           .withArgs(oneWeekSec);
 
-        expect(await staking.epochDuration()).to.equal(oneWeekSec);
+        expect(await staking.nextEpochDuration()).to.equal(oneWeekSec);
+        expect(await staking.currentEpochDuration()).to.equal(currentEpochDuration);
       });
     });
 

--- a/tests/CellarStaking.test.ts
+++ b/tests/CellarStaking.test.ts
@@ -1159,7 +1159,7 @@ describe("CellarStaking", () => {
       });
     });
 
-    describe.only("emergencyUnstake", () => {
+    describe("emergencyUnstake", () => {
       const rewardPerEpoch = ether(oneWeekSec.toString());
 
       beforeEach(async () => {
@@ -1284,9 +1284,6 @@ describe("CellarStaking", () => {
         const balanceAfter = await tokenDist.balanceOf(user.address);
 
         expectRoundedEqual(balanceAfter.sub(balanceBefore), rewardPerEpoch);
-
-        console.log("Total deposits:", await staking.totalDeposits());
-        console.log("Reward claimed:", balanceAfter.sub(balanceBefore));
 
         const contractBalanceAfter = await tokenDist.balanceOf(staking.address);
         expectRoundedEqual(contractBalanceAfter, 0);

--- a/tests/CellarStaking.test.ts
+++ b/tests/CellarStaking.test.ts
@@ -1249,7 +1249,7 @@ describe("CellarStaking", () => {
         await expect(stakingUser.emergencyClaim()).to.be.revertedWith("STATE_NoEmergencyClaim");
       });
 
-      it.only("should allow rewards to be claimable", async () => {
+      it("should allow rewards to be claimable", async () => {
         const { staking, stakingUser, tokenDist, user } = ctx;
 
         // Wait to ensure that depositor not immediately depositing

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -175,7 +175,7 @@ export const setupAdvancedScenario1 = (ctx: TestContext): ScenarioInfo => {
 
   const actions: Action[] = [
     {
-      timestamp: programStart + 5,
+      timestamp: programStart,
       actions: [
         {
           signer: user1,
@@ -269,7 +269,7 @@ export const setupAdvancedScenario2 = (ctx: TestContext): ScenarioInfo => {
 
   const actions: Action[] = [
     {
-      timestamp: programStart + 5,
+      timestamp: programStart,
       actions: [
         {
           signer: user1,
@@ -367,7 +367,7 @@ export const setupAdvancedScenario3 = (ctx: TestContext): ScenarioInfo => {
 
   const actions: Action[] = [
     {
-      timestamp: programStart + 5,
+      timestamp: programStart,
       actions: [
         {
           signer: user1,
@@ -488,7 +488,7 @@ export const setupAdvancedScenario4 = (ctx: TestContext): ScenarioInfo => {
 
   const actions: Action[] = [
     {
-      timestamp: programStart + 5,
+      timestamp: programStart,
       actions: [
         {
           signer: user1,
@@ -639,7 +639,7 @@ export const setupAdvancedScenario5 = (ctx: TestContext): ScenarioInfo => {
 
   const actions: Action[] = [
     {
-      timestamp: programStart + 5,
+      timestamp: programStart,
       actions: [
         {
           signer: user1,
@@ -807,26 +807,12 @@ export const runScenario = async (
   const { staking, signers } = ctx;
   const claims: { [user: string]: BigNumberish } = {};
 
-  let haveNotified = false;
-
   await staking.setRewardsDuration(oneMonthSec);
-
-  const doNotify = async (rewards: BigNumberish) => {
-    if (haveNotified) return;
-
-    await setNextBlockTimestamp(programStart);
-    await staking.notifyRewardAmount(rewards);
-    haveNotified = true;
-  };
+  await staking.notifyRewardAmount(TOTAL_REWARDS);
 
   // Run through scenario from beginning of program until end
   for (const batch of actions) {
     const { timestamp, actions: batchActions } = batch;
-
-    // Make deposit
-    if (timestamp > programStart) {
-      await doNotify(TOTAL_REWARDS);
-    }
 
     await setNextBlockTimestamp(timestamp);
 


### PR DESCRIPTION
Grouped all fixes together since some were intertwined with/dependent on others (like correct accounting for the staking delay being reliant on not losing precision in _earned).

Fixes:

* Remove parentheses in _earned to ensure no precision
* Add proper balance check for an ongoing rewards period in `notifyRewardAmount`
* Add logic in `notifyRewardAmount` to delay starting the reward program if there are no deposits, using a `rewardsReady` variable to track scheduled but pending rewards
* Add logic in `emergencyStop` to run one more accounting cycle and return any leftover to the caller, even if claimable

For the staking delay changes, I tried to check all possible combined conditions of calls. Imagine the following possibilities:

* Reward program state can be `Inactive` (no rewards scheduled), `Pending` (`rewardsReady > 0`), `Active`, or `Expired` (`block.timestamp > endTimestamp`).
* Total deposits can be zero or non-zero

The following should hold under each combination of conditions:
* _Program `Inactive`, deposits 0_: program should move to `Pending`, by setting `rewardsReady`
* _Program `Pending`, deposits 0_: program stays `Pending`, but should add newly-defined rewards to `rewardsReady` by incrementing the value
* _Program `Active`, deposits 0_: This could happen in the case that the rewards program starts, but all depositors fully withdraw. In this case, we will take the same approach as the previous scenario - the current program will be in effect until the next deposit. At the next deposit, `rewardsReady` should also incorporate the leftover, unearned rewards from the previosu period
* _Program `Expired`, deposits 0_: This should be the same as the first scenario. Program should move to pending by setting `rewardsReady`
* _Program `Inactive`, deposits non-zero_: This should never happen, since any deposit before the first schedule should revert with `STATE_NoRewardsLeft`
* _Program `Pending`, deposits non-zero_: Like the above, should never happen, since the pending state will either be skipped if `notifyRewardAmount` is called with non-zero deposits, or advanced through on the first deposit
* _Program `Active`, deposits non-zero_: This should perform a normal advancement of the program and keep the state `Active`. The `endTimestamp` will be immediately increased and the new `rewardRate` immediately calculated.
* _Program `Expired`, deposits non-zero_: Like above, this should immediately begin a new `Active` program. Any depositors should start earning new rewards immediately.

This should mean that after these changes, no funds should get stuck in the contract as a result of scheduling, under any conditions. And, as a result of the `emergencyStop` changes, no funds should get stuck in the contract there either.