### PR TITLE
[audit]: remove parenthesis to ensure order of operations avoids loss of precision

### DIFF
--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -712,7 +712,7 @@ contract CellarStaking is ICellarStaking, Ownable {
      */
     function _earned(UserStake memory s) internal view returns (uint256) {
         uint256 rewardPerTokenAcc = rewardPerTokenStored - s.rewardPerTokenPaid;
-        uint256 newRewards = s.amountWithBoost * (rewardPerTokenAcc / ONE);
+        uint256 newRewards = s.amountWithBoost * rewardPerTokenAcc / ONE;
 
         return newRewards;
     }


### PR DESCRIPTION
See above, one-liner.