### PR TITLE
audit(CellarStaking): Fix "Old stakers can run away with all rewards of the new reward cycle"

### DIFF
--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -599,6 +599,8 @@ contract CellarStaking is ICellarStaking, Ownable {
             // Ready to start
             _startProgram(reward);
         }
+
+        lastAccountingTimestamp = block.timestamp;
     }
 
     /**


### PR DESCRIPTION
Implement recommendation to update `lastAccountingTimestamp` at the end of `notifyRewardAmount`, and add the Macro team's test to the contract's test suite (which should now be testing).