### PR TITLE
audit(CellarStaking): apply gas savings

### DIFF
--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -421,7 +421,6 @@ contract CellarStaking is ICellarStaking, Ownable {
         _updateRewardForStake(msg.sender, depositId);
 
         // Start unstaking
-        uint256 amountWithBoost = s.amountWithBoost;
         reward = s.rewards;
 
         s.amount = 0;
@@ -429,8 +428,9 @@ contract CellarStaking is ICellarStaking, Ownable {
         s.rewards = 0;
 
         // Update global state
+        // Boosted amount same as deposit amount, since we have unbonded
         totalDeposits -= depositAmount;
-        totalDepositsWithBoost -= amountWithBoost;
+        totalDepositsWithBoost -= depositAmount;
 
         // Distribute stake
         stakingToken.safeTransfer(msg.sender, depositAmount);

--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -234,9 +234,9 @@ contract CellarStaking is ICellarStaking, Ownable {
             UserStake({
                 amount: uint112(amount),
                 amountWithBoost: uint112(amountWithBoost),
+                unbondTimestamp: 0,
                 rewardPerTokenPaid: uint112(rewardPerTokenStored),
                 rewards: 0,
-                unbondTimestamp: 0,
                 lock: lock
             })
         );

--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -124,7 +124,6 @@ contract CellarStaking is ICellarStaking, Ownable {
     uint256 public constant ONE_DAY = 60 * 60 * 24;
     uint256 public constant ONE_WEEK = ONE_DAY * 7;
     uint256 public constant TWO_WEEKS = ONE_WEEK * 2;
-    uint256 public constant MAX_UINT = 2**256 - 1;
 
     uint256 public immutable SHORT_BOOST;
     uint256 public immutable MEDIUM_BOOST;

--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -354,8 +354,8 @@ contract CellarStaking is ICellarStaking, Ownable {
 
         // Reinstate
         (uint256 boost, ) = _getBoost(s.lock);
-        uint256 amountWithBoost = s.amount + (s.amount * boost) / ONE;
-        uint256 depositAmountIncreased = amountWithBoost - s.amountWithBoost;
+        uint256 depositAmountIncreased = (s.amount * boost) / ONE;
+        uint256 amountWithBoost = s.amount + depositAmountIncreased;
 
         s.amountWithBoost = uint112(amountWithBoost);
         s.unbondTimestamp = 0;

--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -649,7 +649,7 @@ contract CellarStaking is ICellarStaking, Ownable {
         claimable = makeRewardsClaimable;
         uint256 amountToReturn = distributionToken.balanceOf(address(this));
 
-        if (claimable) {
+        if (makeRewardsClaimable) {
             // Update rewards one more time
             _updateRewards();
 

--- a/src/CellarStaking.sol
+++ b/src/CellarStaking.sol
@@ -687,16 +687,19 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @dev    Sets rewardPerTokenStored.
      *
      *
-     * @return rewardPerToken           The latest time to calculate.
+     * @return newRewardPerTokenStored  The new rewards to distribute per token.
+     * @return latestTimestamp          The latest time to calculate.
      */
-    function rewardPerToken() public view override returns (uint256) {
-        if (totalDeposits == 0) return rewardPerTokenStored;
+    function rewardPerToken() public view override returns (uint256 newRewardPerTokenStored, uint256 latestTimestamp) {
+        latestTimestamp = latestRewardsTimestamp();
 
-        uint256 timeElapsed = latestRewardsTimestamp() - lastAccountingTimestamp;
+        if (totalDeposits == 0) return (rewardPerTokenStored, latestTimestamp);
+
+        uint256 timeElapsed = latestTimestamp - lastAccountingTimestamp;
         uint256 rewardsForTime = timeElapsed * rewardRate;
         uint256 newRewardsPerToken = (rewardsForTime * ONE) / totalDepositsWithBoost;
 
-        return rewardPerTokenStored + newRewardsPerToken;
+        newRewardPerTokenStored = rewardPerTokenStored + newRewardsPerToken;
     }
 
     /**
@@ -735,8 +738,7 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @dev Update reward accounting for the global state totals.
      */
     function _updateRewards() internal {
-        rewardPerTokenStored = rewardPerToken();
-        lastAccountingTimestamp = latestRewardsTimestamp();
+        (rewardPerTokenStored, lastAccountingTimestamp) = rewardPerToken();
     }
 
     /**

--- a/src/interfaces/ICellarStaking.sol
+++ b/src/interfaces/ICellarStaking.sol
@@ -34,9 +34,9 @@ interface ICellarStaking {
     struct UserStake {
         uint112 amount;
         uint112 amountWithBoost;
+        uint32 unbondTimestamp;
         uint112 rewardPerTokenPaid;
         uint112 rewards;
-        uint32 unbondTimestamp;
         Lock lock;
     }
 

--- a/src/interfaces/ICellarStaking.sol
+++ b/src/interfaces/ICellarStaking.sol
@@ -110,7 +110,7 @@ interface ICellarStaking {
 
     function latestRewardsTimestamp() external view returns (uint256);
 
-    function rewardPerToken() external view returns (uint256);
+    function rewardPerToken() external view returns (uint256, uint256);
 
     function getUserStakes(address user) external view returns (UserStake[] memory);
 }

--- a/test/CellarStaking.test.ts
+++ b/test/CellarStaking.test.ts
@@ -1740,7 +1740,7 @@ describe("CellarStaking", () => {
 
         // Half rewards distributed, which means that .5 tokens dist per deposited token
         // Need to divide by one ether since zeroes are added for precision
-        const rewardPerToken = (await stakingUser.rewardPerToken()).div(ether("1"));
+        const rewardPerToken = (await stakingUser.rewardPerToken())[0].div(ether("1"));
         expectRoundedEqual(rewardPerToken, ether(".5"));
       });
 
@@ -1755,7 +1755,7 @@ describe("CellarStaking", () => {
         await stakingUser.unstake(0);
 
         // Get reward per tokenStored
-        const rewardPerToken = await stakingUser.rewardPerToken();
+        const [rewardPerToken] = await stakingUser.rewardPerToken();
         const rewardPerTokenStored = await stakingUser.rewardPerTokenStored();
 
         expect(rewardPerToken).to.equal(rewardPerTokenStored);
@@ -1764,7 +1764,7 @@ describe("CellarStaking", () => {
         await increaseTime(oneMonthSec);
 
         // Check again
-        const newRewardPerToken = await stakingUser.rewardPerToken();
+        const [newRewardPerToken] = await stakingUser.rewardPerToken();
         const newRewardPerTokenStored = await stakingUser.rewardPerTokenStored();
 
         expect(rewardPerTokenStored).to.equal(newRewardPerTokenStored);


### PR DESCRIPTION
**[G-1] Packing variables for efficient read and writes.**
**Status:** Fixed.

**[G-2] UnstakeAll (and all All methods) that write to storage can be condensed.**
**Status:** Won't Fix.
**Comment:** While these savings are significant, given the late-stage nature of this contract and short time to release, this represents more of a change to logic than we are comfortable with (would touch many different lines of code). This can be revisited for future cellars, after our initial release.

**[G-3] Catching latestRewardsTimestamp in _updateRewards()**
**Status:** Fixed.

**[G-4] Stake()  : The check on L216, becomes redundant due to L217**
**Status:** Won't Fix.
**Comment:** Removing the check to the contract not reverting when `minimumDeposit == 0`. We want deposits to revert in that case, without having to explicitly set a non-zero minimum deposit in the constructor.

**[G-5] _cancelUnbonding()** 
**Status:** Fixed.

**[G-6] _unstake(): L420**
**Status:** Won't Fix.
**Comment:** Removing the first check leads to a logical change - if `s.unbondTimestamp` is 0, we want to revert. If `s.unbondTimestamp` were 0 and the first checked was removed, `block.timestamp < 0` would be `false`, and we would not revert.

**[G-7] _unstake()** 
**Status:** Fixed.

**[G-7] _unstake()** 
**Status:** Fixed.

**[G-8] emergencyStop()**
**Status:** Fixed.

Also fixed the code quality issue around an unused `MAX_UINT` variable - as it turns out, we are using `type(uint256).max` in the code below, making this constant unnecessary.

