### PR TITLE
Feat/morpho is borrowing any

### DIFF
--- a/src/interfaces/external/Morpho/IMorphoLensV2.sol
+++ b/src/interfaces/external/Morpho/IMorphoLensV2.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+interface IMorphoLensV2 {
+    function getUserHealthFactor(address user) external view returns (uint256);
+}

--- a/src/modules/adaptors/Morpho/MorphoAaveV2DebtTokenAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV2DebtTokenAdaptor.sol
@@ -119,11 +119,6 @@ contract MorphoAaveV2DebtTokenAdaptor is BaseAdaptor {
      */
     function repayAaveV2MorphoDebt(IAaveToken aToken, uint256 amountToRepay) public {
         ERC20 underlying = ERC20(aToken.UNDERLYING_ASSET_ADDRESS());
-        if (amountToRepay == type(uint256).max) {
-            uint256 availableUnderlying = underlying.balanceOf(address(this));
-            uint256 debt = _balanceOfInUnderlying(address(aToken), address(this));
-            amountToRepay = availableUnderlying > debt ? debt : availableUnderlying;
-        }
         underlying.safeApprove(address(morpho()), amountToRepay);
         morpho().repay(address(aToken), amountToRepay);
 

--- a/src/modules/adaptors/Morpho/MorphoAaveV2DebtTokenAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV2DebtTokenAdaptor.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.16;
 
 import { BaseAdaptor, ERC20, SafeTransferLib, Cellar, Registry, Math } from "src/modules/adaptors/BaseAdaptor.sol";
 import { IMorphoV2 } from "src/interfaces/external/Morpho/IMorphoV2.sol";
+import { IMorphoLensV2 } from "src/interfaces/external/Morpho/IMorphoLensV2.sol";
 import { IAaveToken } from "src/interfaces/external/IAaveToken.sol";
 
 /**
@@ -28,6 +29,11 @@ contract MorphoAaveV2DebtTokenAdaptor is BaseAdaptor {
      */
     error MorphoAaveV2DebtTokenAdaptor__DebtPositionsMustBeTracked(address untrackedDebtPosition);
 
+    /**
+     @notice Attempted borrow would lower Cellar health factor too low.
+     */
+    error MorphoAaveV2DebtTokenAdaptor__HealthFactorTooLow();
+
     //============================================ Global Functions ===========================================
     /**
      * @dev Identifier unique to this adaptor for a shared registry.
@@ -44,6 +50,20 @@ contract MorphoAaveV2DebtTokenAdaptor is BaseAdaptor {
      */
     function morpho() internal pure returns (IMorphoV2) {
         return IMorphoV2(0x777777c9898D384F785Ee44Acfe945efDFf5f3E0);
+    }
+
+    /**
+     * @notice The Morpho Aave V2 Lens contract on Ethereum Mainnet.
+     */
+    function morphoLens() internal pure returns (IMorphoLensV2) {
+        return IMorphoLensV2(0x507fA343d0A90786d86C7cd885f5C49263A91FF4);
+    }
+
+    /**
+     * @notice Minimum Health Factor enforced after every borrow.
+     */
+    function HFMIN() internal pure returns (uint256) {
+        return 1.05e18;
     }
 
     //============================================ Implement Base Functions ===========================================
@@ -110,6 +130,10 @@ contract MorphoAaveV2DebtTokenAdaptor is BaseAdaptor {
 
         // Borrow from morpho.
         morpho().borrow(aToken, amountToBorrow);
+
+        // Check that health factor is above adaptor minimum.
+        uint256 healthFactor = morphoLens().getUserHealthFactor(address(this));
+        if (healthFactor < HFMIN()) revert MorphoAaveV2DebtTokenAdaptor__HealthFactorTooLow();
     }
 
     /**

--- a/src/modules/adaptors/Morpho/MorphoAaveV3ATokenCollateralAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV3ATokenCollateralAdaptor.sol
@@ -23,7 +23,7 @@ contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler
     //====================================================================
 
     /**
-     @notice Attempted borrow would lower Cellar health factor too low.
+     @notice Attempted withdraw would lower Cellar health factor too low.
      */
     error MorphoAaveV3ATokenCollateralAdaptor__HealthFactorTooLow();
 

--- a/src/modules/adaptors/Morpho/MorphoAaveV3ATokenCollateralAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV3ATokenCollateralAdaptor.sol
@@ -4,13 +4,14 @@ pragma solidity 0.8.16;
 import { BaseAdaptor, ERC20, SafeTransferLib } from "src/modules/adaptors/BaseAdaptor.sol";
 import { IMorphoV3 } from "src/interfaces/external/Morpho/IMorphoV3.sol";
 import { MorphoRewardHandler } from "src/modules/adaptors/Morpho/MorphoRewardHandler.sol";
+import { MorphoAaveV3HealthFactorLogic } from "src/modules/adaptors/Morpho/MorphoAaveV3HealthFactorLogic.sol";
 
 /**
  * @title Morpho Aave V3 aToken Adaptor
  * @notice Allows Cellars to interact with Morpho Aave V3 positions.
  * @author crispymangoes
  */
-contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler {
+contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler, MorphoAaveV3HealthFactorLogic {
     using SafeTransferLib for ERC20;
 
     //==================== Adaptor Data Specification ====================
@@ -20,6 +21,11 @@ contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler
     //================= Configuration Data Specification =================
     // NA
     //====================================================================
+
+    /**
+     @notice Attempted borrow would lower Cellar health factor too low.
+     */
+    error MorphoAaveV3ATokenCollateralAdaptor__HealthFactorTooLow();
 
     //============================================ Global Functions ===========================================
     /**
@@ -37,6 +43,13 @@ contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler
      */
     function morpho() internal pure returns (IMorphoV3) {
         return IMorphoV3(0x33333aea097c193e66081E930c33020272b33333);
+    }
+
+    /**
+     * @notice Minimum Health Factor enforced after every withdraw.
+     */
+    function HFMIN() internal pure returns (uint256) {
+        return 1.05e18;
     }
 
     //============================================ Implement Base Functions ===========================================
@@ -137,5 +150,9 @@ contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler
      */
     function withdrawFromAaveV3Morpho(ERC20 tokenToWithdraw, uint256 amountToWithdraw) public {
         morpho().withdrawCollateral(address(tokenToWithdraw), amountToWithdraw, address(this), address(this));
+
+        // Check that health factor is above adaptor minimum.
+        uint256 healthFactor = _getUserHealthFactor(morpho(), address(this));
+        if (healthFactor < HFMIN()) revert MorphoAaveV3ATokenCollateralAdaptor__HealthFactorTooLow();
     }
 }

--- a/src/modules/adaptors/Morpho/MorphoAaveV3HealthFactorLogic.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV3HealthFactorLogic.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import { Math } from "src/utils/Math.sol";
+import { IMorphoV3 } from "src/interfaces/external/Morpho/IMorphoV3.sol";
+
+/**
+ * @title Morpho Aave V3 Health Factor Logic contract.
+ * @notice Implements health factor logic used by both
+ *         the Morpho Aave V3 A Token and debt Token adaptors.
+ * @author crispymangoes
+ */
+contract MorphoAaveV3HealthFactorLogic {
+    using Math for uint256;
+
+    /**
+     * @notice Code pulled directly from Morpho Position Maanager.
+     * https://etherscan.io/address/0x4592e45e0c5DbEe94a135720cCfF2e4353dAc6De#code
+     */
+    function _getUserHealthFactor(IMorphoV3 morpho, address user) internal view returns (uint256) {
+        IMorphoV3.LiquidityData memory liquidityData = morpho.liquidityData(user);
+
+        return
+            liquidityData.debt > 0
+                ? uint256(1e18).mulDivDown(liquidityData.maxDebt, liquidityData.debt)
+                : type(uint256).max;
+    }
+}

--- a/test/testAdaptors/AaveV2Morpho.t.sol
+++ b/test/testAdaptors/AaveV2Morpho.t.sol
@@ -144,7 +144,7 @@ contract CellarAaveV2MorphoTest is Test {
                 "MORPHO Debt Cellar",
                 "MORPHO-CLR",
                 morphoAWethPosition,
-                abi.encode(true),
+                abi.encode(0),
                 strategist
             )
         );
@@ -287,64 +287,65 @@ contract CellarAaveV2MorphoTest is Test {
         assertApproxEqAbs(wethDebt, assets / 8, 1, "WETH debt should equal assets / 8.");
     }
 
-    function testWithdrawalLogic(uint256 assets) external checkBlockNumber {
-        _setupCellarForBorrowing(cellar);
+    function testWithdrawalLogic(uint256 assetsToBorrow) external checkBlockNumber {
+        assetsToBorrow = bound(assetsToBorrow, 1, 1_000e18);
 
-        assets = bound(assets, 0.01e18, 100e18);
-        deal(address(WETH), address(this), assets);
-        cellar.deposit(assets, address(this));
+        uint256 assetsWithdrawable;
+        // Add vanilla WETH to the cellar.
+        cellar.addPosition(0, wethPosition, abi.encode(0), false);
+        // Add debt position to cellar.
+        cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
+
+        uint256 assetsToLend = 2 * assetsToBorrow;
+
+        deal(address(WETH), address(this), assetsToLend);
+        cellar.deposit(assetsToLend, address(this));
+
+        assertTrue(!aTokenAdaptor.isBorrowingAny(address(cellar)), "Cellar should not be borrowing.");
+
+        // Withdrawable assets should equal assetsToLend.
+        assetsWithdrawable = cellar.totalAssetsWithdrawable();
+
+        assertApproxEqAbs(assetsWithdrawable, assetsToLend, 1, "Cellar should be fully liquid.");
 
         // Rebalance Cellar to take on debt.
-        Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](2);
-        // Swap WETH for WSTETH.
+        Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](1);
+        // Borrow WETH from Morpho.
         {
             bytes[] memory adaptorCalls = new bytes[](1);
-            adaptorCalls[0] = _createBytesDataForSwap(WETH, STETH, assets);
-            data[0] = Cellar.AdaptorCall({ adaptor: address(swapWithUniswapAdaptor), callData: adaptorCalls });
-        }
-        // Supply STETH as collateral on Morpho.
-        {
-            bytes[] memory adaptorCalls = new bytes[](1);
-            adaptorCalls[0] = _createBytesDataToLend(aSTETH, type(uint256).max);
-            data[1] = Cellar.AdaptorCall({ adaptor: address(aTokenAdaptor), callData: adaptorCalls });
+            adaptorCalls[0] = _createBytesDataToBorrow(aWETH, assetsToBorrow);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
         }
 
         // Perform callOnAdaptor.
         cellar.callOnAdaptor(data);
 
-        // Cellar now has debt so withdrawable assets should be zero.
-        uint256 withdrawable = cellar.totalAssetsWithdrawable();
-        assertEq(withdrawable, 0, "Cellar should have no assets withdrawable.");
+        deal(address(WETH), address(cellar), assetsToBorrow + 1);
 
-        // Strategist rebalances out of Morpho STETH so it position can be removed, and made liquid.
+        assertTrue(aTokenAdaptor.isBorrowingAny(address(cellar)), "Cellar should be borrowing.");
+
+        // Withdrawable assets should equal assetsToBorrow.
+        assetsWithdrawable = cellar.totalAssetsWithdrawable();
+
+        assertApproxEqAbs(assetsWithdrawable, assetsToBorrow, 1, "Cellar aToken position should be illiquid.");
+
+        // Rebalance Cellar to repay debt in full.
         data = new Cellar.AdaptorCall[](1);
-        // Swap WETH for WSTETH.
         {
             bytes[] memory adaptorCalls = new bytes[](1);
-            adaptorCalls[0] = _createBytesDataToWithdraw(aSTETH, type(uint256).max);
-            data[0] = Cellar.AdaptorCall({ adaptor: address(aTokenAdaptor), callData: adaptorCalls });
+            adaptorCalls[0] = _createBytesDataToRepay(address(aWETH), type(uint256).max);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
         }
 
         // Perform callOnAdaptor.
         cellar.callOnAdaptor(data);
 
-        cellar.removePosition(2, false);
-        // Re-add the position but this time make it liquid.
-        cellar.addPosition(0, morphoAStEthPosition, abi.encode(true), false);
+        assertTrue(!aTokenAdaptor.isBorrowingAny(address(cellar)), "Cellar should not be borrowing.");
 
-        withdrawable = cellar.totalAssetsWithdrawable();
-        uint256 totalAssets = cellar.totalAssets();
-        assertEq(withdrawable, totalAssets, "Cellar should have all assets withdrawable.");
+        // Withdrawable assets should equal assetsToLend.
+        assetsWithdrawable = cellar.totalAssetsWithdrawable();
 
-        uint256 maxAssets = cellar.maxWithdraw(address(this));
-        cellar.withdraw(maxAssets, address(this), address(this));
-        uint256 expectedOut = priceRouter.getValue(WETH, maxAssets, STETH);
-        assertApproxEqAbs(
-            STETH.balanceOf(address(this)),
-            expectedOut,
-            1,
-            "Withdraw should have sent collateral assets to user."
-        );
+        assertApproxEqAbs(assetsWithdrawable, assetsToLend, 2, "Cellar should be fully liquid.");
     }
 
     function testTakingOutLoansInUntrackedPosition(uint256 assets) external checkBlockNumber {
@@ -596,13 +597,58 @@ contract CellarAaveV2MorphoTest is Test {
         cellar.callOnAdaptor(data);
     }
 
+    function testIsBorrowingAnyFullRepay(uint256 assetsToBorrow) external checkBlockNumber {
+        assetsToBorrow = bound(assetsToBorrow, 1, 1_000e18);
+
+        // Add vanilla WETH to the cellar.
+        cellar.addPosition(0, wethPosition, abi.encode(0), false);
+        // Add debt position to cellar.
+        cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
+
+        uint256 assetsToLend = 2 * assetsToBorrow;
+
+        deal(address(WETH), address(this), assetsToLend);
+        cellar.deposit(assetsToLend, address(this));
+
+        assertTrue(!aTokenAdaptor.isBorrowingAny(address(cellar)), "Cellar should not be borrowing.");
+
+        // Rebalance Cellar to take on debt.
+        Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](1);
+        // Borrow WETH from Morpho.
+        {
+            bytes[] memory adaptorCalls = new bytes[](1);
+            adaptorCalls[0] = _createBytesDataToBorrow(aWETH, assetsToBorrow);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
+        }
+
+        // Perform callOnAdaptor.
+        cellar.callOnAdaptor(data);
+
+        deal(address(WETH), address(cellar), assetsToBorrow + 1);
+
+        assertTrue(aTokenAdaptor.isBorrowingAny(address(cellar)), "Cellar should be borrowing.");
+
+        // Rebalance Cellar to repay debt in full.
+        data = new Cellar.AdaptorCall[](1);
+        {
+            bytes[] memory adaptorCalls = new bytes[](1);
+            adaptorCalls[0] = _createBytesDataToRepay(address(aWETH), type(uint256).max);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
+        }
+
+        // Perform callOnAdaptor.
+        cellar.callOnAdaptor(data);
+
+        assertTrue(!aTokenAdaptor.isBorrowingAny(address(cellar)), "Cellar should not be borrowing.");
+    }
+
     // ========================================= HELPER FUNCTIONS =========================================
 
     function _setupCellarForBorrowing(Cellar target) internal {
         // Add required positions.
         target.addPosition(0, wethPosition, abi.encode(0), false);
         target.addPosition(1, stethPosition, abi.encode(0), false);
-        target.addPosition(2, morphoAStEthPosition, abi.encode(false), false);
+        target.addPosition(2, morphoAStEthPosition, abi.encode(0), false);
         target.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
 
         // Change holding position to vanilla WETH.
@@ -678,84 +724,4 @@ contract CellarAaveV2MorphoTest is Test {
                 amountToRepay
             );
     }
-
-    function testIsBorrowingAnyFullRepay(uint256 assetsToBorrow) external checkBlockNumber {
-        assetsToBorrow = bound(assetsToBorrow, 1, 1_000e18);
-
-        uint256 morphoDebt;
-        // Add vanilla WETH to the cellar.
-        cellar.addPosition(0, wethPosition, abi.encode(0), false);
-        // Add debt position to cellar.
-        cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
-
-        uint256 assetsToLend = 2 * assetsToBorrow;
-
-        deal(address(WETH), address(this), assetsToLend);
-        cellar.deposit(assetsToLend, address(this));
-
-        assertTrue(!isBorrowing(address(cellar)), "Cellar should not be borrowing.");
-
-        // Rebalance Cellar to take on debt.
-        Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](1);
-        // Borrow WETH from Morpho.
-        {
-            bytes[] memory adaptorCalls = new bytes[](1);
-            adaptorCalls[0] = _createBytesDataToBorrow(aWETH, assetsToBorrow);
-            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
-        }
-
-        // Perform callOnAdaptor.
-        cellar.callOnAdaptor(data);
-
-        assertTrue(isBorrowing(address(cellar)), "Cellar should be borrowing.");
-
-        // Advance time so that cellar takes on some debt.
-        // vm.roll(block.number + 100);
-        // vm.warp(block.timestamp + (1 days / 2));
-
-        // // Make sure debt increased.
-        // morphoDebt = getMorphoDebt(aWETH, address(cellar));
-
-        // assertGt(morphoDebt, assetsToBorrow, "Cellar should have more debt.");
-
-        // Rebalance Cellar to repay debt in full.
-        data = new Cellar.AdaptorCall[](1);
-        {
-            bytes[] memory adaptorCalls = new bytes[](1);
-            adaptorCalls[0] = _createBytesDataToRepay(address(aWETH), type(uint256).max);
-            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
-        }
-
-        // Perform callOnAdaptor.
-        cellar.callOnAdaptor(data);
-
-        if (isBorrowing(address(cellar))) {
-            // TODO uncommenting the below line, runs the same callOnAdaptor call again.
-            // doing this seems to fix the issue of some calls leaving 1 wei of debt.
-            // cellar.callOnAdaptor(data);
-
-            morphoDebt = getMorphoDebt(aWETH, address(cellar));
-            console.log("Debt", morphoDebt);
-        }
-
-        assertTrue(!isBorrowing(address(cellar)), "Cellar should not be borrowing.");
-    }
-
-    function testIsBorrowingAnyPartialRepayThenFullRepay() external {}
-
-    function testIsBorrowingAnyRepayAllButOneWeiThenFullRepay() external {}
-
-    function isBorrowing(address user) internal view returns (bool) {
-        bytes32 userMarkets = morpho.userMarkets(user);
-        return _isBorrowingAny(userMarkets);
-    }
-
-    /// @dev Returns if a user has been borrowing from any market.
-    /// @param _userMarkets The bitmask encoding the markets entered by the user.
-    /// @return True if the user has been borrowing on any market, false otherwise.
-    function _isBorrowingAny(bytes32 _userMarkets) internal pure returns (bool) {
-        return _userMarkets & BORROWING_MASK != 0;
-    }
-
-    bytes32 public constant BORROWING_MASK = 0x5555555555555555555555555555555555555555555555555555555555555555;
 }

--- a/test/testAdaptors/AaveV3Morpho.t.sol
+++ b/test/testAdaptors/AaveV3Morpho.t.sol
@@ -549,7 +549,7 @@ contract CellarAaveV3MorphoTest is Test {
         );
     }
 
-    function testHealthFactorChecks() external {
+    function testHealthFactorChecks() external checkBlockNumber {
         // Need to borrow, and lower the health factor below 1.05, then need to withdraw to lower health factor below 1.05.
         _setupCellarForBorrowing(cellar);
 

--- a/test/testAdaptors/AaveV3Morpho.t.sol
+++ b/test/testAdaptors/AaveV3Morpho.t.sol
@@ -549,6 +549,80 @@ contract CellarAaveV3MorphoTest is Test {
         );
     }
 
+    function testHealthFactorChecks() external {
+        // Need to borrow, and lower the health factor below 1.05, then need to withdraw to lower health factor below 1.05.
+        _setupCellarForBorrowing(cellar);
+
+        uint256 assets = 100e18;
+        deal(address(WETH), address(this), assets);
+        cellar.deposit(assets, address(this));
+
+        // Simulate a swap by minting cellar the correct amount of WSTETH.
+        deal(address(WETH), address(cellar), 0);
+        uint256 wstEthToMint = priceRouter.getValue(WETH, assets, WSTETH);
+        deal(address(WSTETH), address(cellar), wstEthToMint);
+
+        uint256 targetHealthFactor = 1.052e18;
+        uint256 ltv = 0.93e18;
+        uint256 wethToBorrow = assets.mulDivDown(ltv, targetHealthFactor);
+        uint256 wethToBorrowToTriggerHealthFactorRevert = assets.mulDivDown(ltv, 1.04e18) - wethToBorrow;
+
+        // Rebalance Cellar to take on debt.
+        Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](2);
+        // Supply WSTETH as collateral on Morpho.
+        {
+            bytes[] memory adaptorCalls = new bytes[](1);
+            adaptorCalls[0] = _createBytesDataToLend(WSTETH, wstEthToMint);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(collateralATokenAdaptor), callData: adaptorCalls });
+        }
+        // Borrow WETH from Morpho.
+        {
+            bytes[] memory adaptorCalls = new bytes[](1);
+            adaptorCalls[0] = _createBytesDataToBorrow(WETH, wethToBorrow, 4);
+            data[1] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
+        }
+
+        // Perform callOnAdaptor.
+        cellar.callOnAdaptor(data);
+
+        // Strategist tries to borrow more.
+        data = new Cellar.AdaptorCall[](1);
+        // Borrow WETH from Morpho.
+        {
+            bytes[] memory adaptorCalls = new bytes[](1);
+            adaptorCalls[0] = _createBytesDataToBorrow(WETH, wethToBorrowToTriggerHealthFactorRevert, 4);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(debtTokenAdaptor), callData: adaptorCalls });
+        }
+
+        // callOnAdaptor reverts because the health factor is too low.
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    MorphoAaveV3DebtTokenAdaptor.MorphoAaveV3DebtTokenAdaptor__HealthFactorTooLow.selector
+                )
+            )
+        );
+        cellar.callOnAdaptor(data);
+
+        // If strategist tries to withdraw some collateral, the withdraw also reverts.
+        {
+            bytes[] memory adaptorCalls = new bytes[](1);
+            uint256 amountToWithdraw = 1e18;
+            adaptorCalls[0] = _createBytesDataToWithdraw(WSTETH, amountToWithdraw);
+            data[0] = Cellar.AdaptorCall({ adaptor: address(collateralATokenAdaptor), callData: adaptorCalls });
+        }
+
+        // callOnAdaptor should revert because withdraw lowers Health Factor too far.
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    MorphoAaveV3ATokenCollateralAdaptor.MorphoAaveV3ATokenCollateralAdaptor__HealthFactorTooLow.selector
+                )
+            )
+        );
+        cellar.callOnAdaptor(data);
+    }
+
     // ========================================== INTEGRATION TEST ==========================================
 
     function testIntegrationRealYieldEth(uint256 assets) external checkBlockNumber {


### PR DESCRIPTION
This PR fixes the Morpho Aave V2 debt token adaptor logic so that calling the strategist repay function will always repay the full amount of debt, where as before it would sometimes leave 1 wei of debt behind. 

In addition to the above it also removes the `isLiquid` configuration bool from the Morpho Aave V2 aToken adaptor, and instead reads the cellars `userMarkets` to determine if the cellar has any active loans. If the cellar has no active loans, the aToken position is liquid, otherwise the aToken position is illiquid.