### PR TITLE
Fix/macro audit 8

### DIFF
--- a/src/mocks/adaptors/MockFTokenAdaptor.sol
+++ b/src/mocks/adaptors/MockFTokenAdaptor.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.16;
 import { FTokenAdaptor, IFToken } from "src/modules/adaptors/Frax/FTokenAdaptor.sol";
 
 contract MockFTokenAdaptor is FTokenAdaptor {
+    constructor(bool _accountForInterest) FTokenAdaptor(_accountForInterest) {}
+
     //============================================ Interface Helper Functions ===========================================
 
     /**
@@ -14,9 +16,5 @@ contract MockFTokenAdaptor is FTokenAdaptor {
      */
     function identifier() public pure override returns (bytes32) {
         return keccak256(abi.encode("Mock FraxLend fToken Adaptor V 0.0"));
-    }
-
-    function ACCOUNT_FOR_INTEREST() internal pure override returns (bool) {
-        return false;
     }
 }

--- a/src/mocks/adaptors/MockFTokenAdaptorV1.sol
+++ b/src/mocks/adaptors/MockFTokenAdaptorV1.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.16;
 import { FTokenAdaptorV1, IFToken } from "src/modules/adaptors/Frax/FTokenAdaptorV1.sol";
 
 contract MockFTokenAdaptorV1 is FTokenAdaptorV1 {
+    constructor(bool _accountForInterest) FTokenAdaptorV1(_accountForInterest) {}
+
     //============================================ Interface Helper Functions ===========================================
 
     /**
@@ -14,9 +16,5 @@ contract MockFTokenAdaptorV1 is FTokenAdaptorV1 {
      */
     function identifier() public pure override returns (bytes32) {
         return keccak256(abi.encode("Mock FraxLend fTokenV1 Adaptor V 0.0"));
-    }
-
-    function ACCOUNT_FOR_INTEREST() internal pure override returns (bool) {
-        return false;
     }
 }

--- a/src/modules/adaptors/Frax/FTokenAdaptor.sol
+++ b/src/modules/adaptors/Frax/FTokenAdaptor.sol
@@ -8,7 +8,7 @@ import { IFToken } from "src/interfaces/external/Frax/IFToken.sol";
  * @title FraxLend fToken Adaptor
  * @dev This adaptor is specifically for FraxLendPairV2 contracts.
  *      To interact with a different version, inherit from this adaptor
- *      and overrid the interface helper functions.
+ *      and override the interface helper functions.
  * @notice Allows Cellars to lend FRAX to FraxLend pairs.
  * @author crispymangoes, 0xEinCodes
  */

--- a/src/modules/adaptors/Frax/FTokenAdaptor.sol
+++ b/src/modules/adaptors/Frax/FTokenAdaptor.sol
@@ -29,6 +29,17 @@ contract FTokenAdaptor is BaseAdaptor {
      */
     error FTokenAdaptor__FTokenPositionsMustBeTracked(address fToken);
 
+    /**
+     * @notice This bool determines how this adaptor accounts for interest.
+     *         True: Account for pending interest to be paid when calling `balanceOf` or `withdrawableFrom`.
+     *         False: Do not account for pending interest to be paid when calling `balanceOf` or `withdrawableFrom`.
+     */
+    bool public immutable ACCOUNT_FOR_INTEREST;
+
+    constructor(bool _accountForInterest) {
+        ACCOUNT_FOR_INTEREST = _accountForInterest;
+    }
+
     //============================================ Global Functions ===========================================
     /**
      * @dev Identifier unique to this adaptor for a shared registry.
@@ -45,17 +56,6 @@ contract FTokenAdaptor is BaseAdaptor {
      */
     function FRAX() internal pure returns (ERC20) {
         return ERC20(0x853d955aCEf822Db058eb8505911ED77F175b99e);
-    }
-
-    /**
-     * @notice Indicates whether or not we should worry about updating interest
-     *         when interacting with FraxLend.
-     * @dev True is the most accurate method, but will slightly add to gas costs.
-     *      False is less accurate, but this error is mitigated by the frequency the
-     *      FraxLend Pairs are interacted with.
-     */
-    function ACCOUNT_FOR_INTEREST() internal pure virtual returns (bool) {
-        return true;
     }
 
     //============================================ Implement Base Functions ===========================================
@@ -105,7 +105,7 @@ contract FTokenAdaptor is BaseAdaptor {
         (uint128 totalFraxSupplied, , uint128 totalFraxBorrowed, , ) = _getPairAccounting(fToken);
         if (totalFraxBorrowed >= totalFraxSupplied) return 0;
         uint256 liquidFrax = totalFraxSupplied - totalFraxBorrowed;
-        uint256 fraxBalance = _toAssetAmount(fToken, _balanceOf(fToken, msg.sender), false, ACCOUNT_FOR_INTEREST());
+        uint256 fraxBalance = _toAssetAmount(fToken, _balanceOf(fToken, msg.sender), false, ACCOUNT_FOR_INTEREST);
         withdrawableFrax = fraxBalance > liquidFrax ? liquidFrax : fraxBalance;
     }
 
@@ -114,7 +114,7 @@ contract FTokenAdaptor is BaseAdaptor {
      */
     function balanceOf(bytes memory adaptorData) public view override returns (uint256) {
         IFToken fToken = abi.decode(adaptorData, (IFToken));
-        return _toAssetAmount(fToken, _balanceOf(fToken, msg.sender), false, ACCOUNT_FOR_INTEREST());
+        return _toAssetAmount(fToken, _balanceOf(fToken, msg.sender), false, ACCOUNT_FOR_INTEREST);
     }
 
     /**

--- a/src/modules/adaptors/Frax/FTokenAdaptorV1.sol
+++ b/src/modules/adaptors/Frax/FTokenAdaptorV1.sol
@@ -17,6 +17,8 @@ contract FTokenAdaptorV1 is FTokenAdaptor {
     // This can be mitigated by calling `callAddInterest` on Frax Lend pairs
     // that are not frequently interacted with.
 
+    constructor(bool _accountForInterest) FTokenAdaptor(_accountForInterest) {}
+
     //============================================ Interface Helper Functions ===========================================
 
     //============================== Interface Details ==============================
@@ -52,7 +54,7 @@ contract FTokenAdaptorV1 is FTokenAdaptor {
      * @notice Withdraw $FRAX from specified 'v1' FraxLendPair.
      * @dev Since `withdrawableFrom` does NOT account for pending interest,
      *      user withdraws from V1 positions can result in dust being left in the position.
-     * @dev If `ACCOUNT_FOR_INTEREST()` is false, then _toAssetShares will use a FraxLend share price that
+     * @dev If `ACCOUNT_FOR_INTEREST` is false, then _toAssetShares will use a FraxLend share price that
      *      is slightly lower than what is used in redeem, so users can receive more assets than expected.
      *      The extra assets are influenced by the FraxLend APR, and the time since the interest was last
      *      added to the pair, so in practice this extra amount should be negligible.
@@ -63,8 +65,8 @@ contract FTokenAdaptorV1 is FTokenAdaptor {
      */
     function _withdraw(IFToken fToken, uint256 assets, address receiver, address owner) internal override {
         // If accounting for interest, call `addInterest` before calculating shares to redeem.
-        if (ACCOUNT_FOR_INTEREST()) fToken.addInterest();
-        uint256 shares = _toAssetShares(fToken, assets, false, ACCOUNT_FOR_INTEREST());
+        if (ACCOUNT_FOR_INTEREST) fToken.addInterest();
+        uint256 shares = _toAssetShares(fToken, assets, false, ACCOUNT_FOR_INTEREST);
         fToken.redeem(shares, receiver, owner);
     }
 

--- a/src/modules/adaptors/Morpho/MorphoAaveV2ATokenAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV2ATokenAdaptor.sol
@@ -108,7 +108,8 @@ contract MorphoAaveV2ATokenAdaptor is BaseAdaptor, MorphoRewardHandler {
     }
 
     /**
-     * @notice Uses configuration data to determine if the position is liquid or not.
+     * @notice Checks if Cellar has open borrows, and if so returns zero.
+     *         Otherwise returns balanceOf in underlying.
      * @param adaptorData the abi encoded aToken address
      */
     function withdrawableFrom(bytes memory adaptorData, bytes memory) public view override returns (uint256) {

--- a/src/modules/adaptors/Morpho/MorphoAaveV2ATokenAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV2ATokenAdaptor.sol
@@ -21,14 +21,7 @@ contract MorphoAaveV2ATokenAdaptor is BaseAdaptor, MorphoRewardHandler {
     // Where:
     // `aToken` is the AaveV2 A Token position this adaptor is working with
     //================= Configuration Data Specification =================
-    // isLiquid bool indicating whether user withdraws are allowed from this position.
-    // IMPORTANT: It is possible for a strategist to misconfigure their positions,
-    // and allow user withdraws from aToken positions that are backing loans.
-    // This will be mitigated by only allowing trusted strategists to use this adaptor,
-    // and educating them the dangers of misconfiguring their position.
-    // EX: If a cellar is using their aTokens to back a borrow, then strategists
-    // should make their aToken positions illiquid, so that user withdraws do not
-    // negatively affect the cellars health factor.
+    // NA
     //====================================================================
 
     /**
@@ -116,6 +109,7 @@ contract MorphoAaveV2ATokenAdaptor is BaseAdaptor, MorphoRewardHandler {
 
     /**
      * @notice Uses configuration data to determine if the position is liquid or not.
+     * @param adaptorData the abi encoded aToken address
      */
     function withdrawableFrom(bytes memory adaptorData, bytes memory) public view override returns (uint256) {
         // If position is backing a borrow, then return 0.

--- a/src/modules/adaptors/Morpho/MorphoAaveV2ATokenAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV2ATokenAdaptor.sol
@@ -101,10 +101,10 @@ contract MorphoAaveV2ATokenAdaptor is BaseAdaptor, MorphoRewardHandler {
         // Make sure position is not backing a borrow.
         if (isBorrowingAny(address(this))) revert BaseAdaptor__UserWithdrawsNotAllowed();
 
-        IAaveToken aToken = abi.decode(adaptorData, (IAaveToken));
+        address aToken = abi.decode(adaptorData, (address));
 
         // Withdraw assets from Morpho.
-        morpho().withdraw(address(aToken), assets, receiver);
+        morpho().withdraw(aToken, assets, receiver);
     }
 
     /**
@@ -133,7 +133,7 @@ contract MorphoAaveV2ATokenAdaptor is BaseAdaptor, MorphoRewardHandler {
      * @notice Returns the positions aToken underlying asset.
      */
     function assetOf(bytes memory adaptorData) public view override returns (ERC20) {
-        IAaveToken token = IAaveToken(abi.decode(adaptorData, (address)));
+        IAaveToken token = abi.decode(adaptorData, (IAaveToken));
         return ERC20(token.UNDERLYING_ASSET_ADDRESS());
     }
 

--- a/src/modules/adaptors/Morpho/MorphoAaveV3ATokenCollateralAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV3ATokenCollateralAdaptor.sol
@@ -86,21 +86,21 @@ contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler
         address[] memory borrows = morpho().userBorrows(address(this));
         if (borrows.length > 0) revert BaseAdaptor__UserWithdrawsNotAllowed();
 
-        ERC20 underlying = abi.decode(adaptorData, (ERC20));
+        address underlying = abi.decode(adaptorData, (address));
 
         // Withdraw assets from Morpho.
-        morpho().withdrawCollateral(address(underlying), assets, address(this), receiver);
+        morpho().withdrawCollateral(underlying, assets, address(this), receiver);
     }
 
     /**
-     * @notice Checks that cellar has no active borrows, and if so reverts.
+     * @notice Checks that cellar has no active borrows, and if so returns 0.
      */
     function withdrawableFrom(bytes memory adaptorData, bytes memory) public view override returns (uint256) {
         address[] memory borrows = morpho().userBorrows(msg.sender);
         if (borrows.length > 0) return 0;
         else {
-            ERC20 underlying = abi.decode(adaptorData, (ERC20));
-            return morpho().collateralBalance(address(underlying), msg.sender);
+            address underlying = abi.decode(adaptorData, (address));
+            return morpho().collateralBalance(underlying, msg.sender);
         }
     }
 
@@ -108,8 +108,8 @@ contract MorphoAaveV3ATokenCollateralAdaptor is BaseAdaptor, MorphoRewardHandler
      * @notice Returns the cellars balance of the position in terms of underlying asset.
      */
     function balanceOf(bytes memory adaptorData) public view override returns (uint256) {
-        ERC20 underlying = abi.decode(adaptorData, (ERC20));
-        return morpho().collateralBalance(address(underlying), msg.sender);
+        address underlying = abi.decode(adaptorData, (address));
+        return morpho().collateralBalance(underlying, msg.sender);
     }
 
     /**

--- a/src/modules/adaptors/Morpho/MorphoAaveV3ATokenP2PAdaptor.sol
+++ b/src/modules/adaptors/Morpho/MorphoAaveV3ATokenP2PAdaptor.sol
@@ -82,27 +82,27 @@ contract MorphoAaveV3ATokenP2PAdaptor is BaseAdaptor, MorphoRewardHandler {
         // Run external receiver check.
         _externalReceiverCheck(receiver);
 
-        ERC20 underlying = abi.decode(adaptorData, (ERC20));
+        address underlying = abi.decode(adaptorData, (address));
         uint256 iterations = abi.decode(configurationData, (uint256));
 
         // Withdraw assets from Morpho.
-        morpho().withdraw(address(underlying), assets, address(this), receiver, iterations);
+        morpho().withdraw(underlying, assets, address(this), receiver, iterations);
     }
 
     /**
      * @notice Returns the p2p balance of the cellar.
      */
     function withdrawableFrom(bytes memory adaptorData, bytes memory) public view override returns (uint256) {
-        ERC20 underlying = abi.decode(adaptorData, (ERC20));
-        return morpho().supplyBalance(address(underlying), msg.sender);
+        address underlying = abi.decode(adaptorData, (address));
+        return morpho().supplyBalance(underlying, msg.sender);
     }
 
     /**
      * @notice Returns the cellars p2p balance.
      */
     function balanceOf(bytes memory adaptorData) public view override returns (uint256) {
-        ERC20 underlying = abi.decode(adaptorData, (ERC20));
-        return morpho().supplyBalance(address(underlying), msg.sender);
+        address underlying = abi.decode(adaptorData, (address));
+        return morpho().supplyBalance(underlying, msg.sender);
     }
 
     /**

--- a/src/modules/price-router/Extensions/Balancer/BalancerPoolExtension.sol
+++ b/src/modules/price-router/Extensions/Balancer/BalancerPoolExtension.sol
@@ -40,24 +40,51 @@ abstract contract BalancerPoolExtension is Extension {
      * here (https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345), those functions are unsafe,
      * and subject to manipulation that may result in loss of funds.
      */
-    function _ensureNotInVaultContext(IVault vault) internal view {
-        // Perform the following operation to trigger the Vault's reentrancy guard.
-        // Use a static call so that it can be a view function (even though the
-        // function is non-view).
+    function ensureNotInVaultContext(IVault vault) internal view {
+        // Perform the following operation to trigger the Vault's reentrancy guard:
         //
         // IVault.UserBalanceOp[] memory noop = new IVault.UserBalanceOp[](0);
         // _vault.manageUserBalance(noop);
+        //
+        // However, use a static call so that it can be a view function (even though the function is non-view).
+        // This allows the library to be used more widely, as some functions that need to be protected might be
+        // view.
+        //
+        // This staticcall always reverts, but we need to make sure it doesn't fail due to a re-entrancy attack.
+        // Staticcalls consume all gas forwarded to them on a revert caused by storage modification.
+        // By default, almost the entire available gas is forwarded to the staticcall,
+        // causing the entire call to revert with an 'out of gas' error.
+        //
+        // We set the gas limit to 10k for the staticcall to
+        // avoid wasting gas when it reverts due to storage modification.
+        // `manageUserBalance` is a non-reentrant function in the Vault, so calling it invokes `_enterNonReentrant`
+        // in the `ReentrancyGuard` contract, reproduced here:
+        //
+        //    function _enterNonReentrant() private {
+        //        // If the Vault is actually being reentered, it will revert in the first line, at the `_require` that
+        //        // checks the reentrancy flag, with "BAL#400" (corresponding to Errors.REENTRANCY) in the revertData.
+        //        // The full revertData will be: `abi.encodeWithSignature("Error(string)", "BAL#400")`.
+        //        _require(_status != _ENTERED, Errors.REENTRANCY);
+        //
+        //        // If the Vault is not being reentered, the check above will pass: but it will *still* revert,
+        //        // because the next line attempts to modify storage during a staticcall. However, this type of
+        //        // failure results in empty revertData.
+        //        _status = _ENTERED;
+        //    }
+        //
+        // So based on this analysis, there are only two possible revertData values: empty, or abi.encoded BAL#400.
+        //
+        // It is of course much more bytecode and gas efficient to check for zero-length revertData than to compare it
+        // to the encoded REENTRANCY revertData.
+        //
+        // While it should be impossible for the call to fail in any other way (especially since it reverts before
+        // `manageUserBalance` even gets called), any other error would generate non-zero revertData, so checking for
+        // empty data guards against this case too.
 
-        // solhint-disable-next-line var-name-mixedcase
-        bytes32 REENTRANCY_ERROR_HASH = keccak256(abi.encodeWithSignature("Error(string)", "BAL#400"));
-
-        // read-only re-entrancy protection - this call is always unsuccessful but we need to make sure
-        // it didn't fail due to a re-entrancy attack
-        // This might just look like an issue in foundry. Running a testnet test does not use an insane amount of gas.
-        (, bytes memory revertData) = address(vault).staticcall(
-            abi.encodeWithSelector(vault.manageUserBalance.selector, new address[](0))
+        (, bytes memory revertData) = address(vault).staticcall{ gas: 10_000 }(
+            abi.encodeWithSelector(vault.manageUserBalance.selector, 0)
         );
 
-        if (keccak256(revertData) == REENTRANCY_ERROR_HASH) revert BalancerPoolExtension__Reentrancy();
+        if (revertData.length != 0) revert BalancerPoolExtension__Reentrancy();
     }
 }

--- a/src/modules/price-router/Extensions/Balancer/BalancerStablePoolExtension.sol
+++ b/src/modules/price-router/Extensions/Balancer/BalancerStablePoolExtension.sol
@@ -101,7 +101,7 @@ contract BalancerStablePoolExtension is BalancerPoolExtension {
      * @param asset the BPT token
      */
     function getPriceInUSD(ERC20 asset) external view override returns (uint256) {
-        _ensureNotInVaultContext(balancerVault);
+        ensureNotInVaultContext(balancerVault);
         IBalancerPool pool = IBalancerPool(address(asset));
 
         // Read extension storage and grab pool tokens

--- a/src/modules/price-router/Extensions/Lido/WstEthExtension.sol
+++ b/src/modules/price-router/Extensions/Lido/WstEthExtension.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.16;
 
 import { Extension, PriceRouter, ERC20, Math } from "src/modules/price-router/Extensions/Extension.sol";
-import { IChainlinkAggregator } from "src/interfaces/external/IChainlinkAggregator.sol";
 import { ISTETH } from "src/interfaces/external/ISTETH.sol";
 
 /**

--- a/src/modules/price-router/PriceRouter.sol
+++ b/src/modules/price-router/PriceRouter.sol
@@ -471,7 +471,7 @@ contract PriceRouter is Ownable {
 
         uint256 numOfAssets = baseAssets.length;
         exchangeRates = new uint256[](numOfAssets);
-        for (uint256 i; i < numOfAssets; i++) {
+        for (uint256 i; i < numOfAssets; ++i) {
             AssetSettings memory baseSettings = getAssetSettings[baseAssets[i]];
             if (baseSettings.derivative == 0) revert PriceRouter__UnsupportedAsset(address(baseAssets[i]));
             exchangeRates[i] = _getExchangeRate(
@@ -582,7 +582,7 @@ contract PriceRouter is Ownable {
         uint256 valueInQuote;
         uint8 quoteDecimals = quoteAsset.decimals();
 
-        for (uint8 i = 0; i < baseAssets.length; i++) {
+        for (uint256 i = 0; i < baseAssets.length; ++i) {
             // Skip zero amount values.
             if (amounts[i] == 0) continue;
             ERC20 baseAsset = baseAssets[i];

--- a/test/testAdaptors/FraxLendFToken.t.sol
+++ b/test/testAdaptors/FraxLendFToken.t.sol
@@ -78,10 +78,10 @@ contract FraxLendFTokenAdaptorTest is Test {
     function setUp() external {
         mockFraxUsd = new MockDataFeed(FRAX_USD_FEED);
         mockWethUsd = new MockDataFeed(WETH_USD_FEED);
-        fTokenAdaptorV2 = new FTokenAdaptor();
-        fTokenAdaptor = new FTokenAdaptorV1();
-        mockFTokenAdaptorV2 = new MockFTokenAdaptor();
-        mockFTokenAdaptor = new MockFTokenAdaptorV1();
+        fTokenAdaptorV2 = new FTokenAdaptor(true);
+        fTokenAdaptor = new FTokenAdaptorV1(true);
+        mockFTokenAdaptorV2 = new MockFTokenAdaptor(false);
+        mockFTokenAdaptor = new MockFTokenAdaptorV1(false);
         erc20Adaptor = new ERC20Adaptor();
 
         registry = new Registry(address(this), address(this), address(priceRouter));


### PR DESCRIPTION
This PR implements fixes described in the Macro Audit-8 Preliminary report.

Note M-1 and M-2 were fixed in #123 .

In addition to the fixes, the FTokenAdaptor was updated to replace the `ACCOUNT_FOR_INTEREST()` global function with an immutable bool. This makes deployments of FTokenAdaptors easier because we do not need to change the adaptor code, we only need to specify a different constructor input.