### PR TITLE
Make adjustments to Fraxlend Adaptors as per Feedback from Strategists

### DIFF
--- a/src/interfaces/external/Frax/IFToken.sol
+++ b/src/interfaces/external/Frax/IFToken.sol
@@ -85,6 +85,14 @@ interface IFToken {
 
     function toBorrowAmount(uint256 _shares, bool _roundUp) external view returns (uint256 _amount);
 
+    function toBorrowShares(
+        uint256 _amount,
+        bool _roundUp,
+        bool _previewInterest
+    ) external view returns (uint256 _shares);
+
+    function toBorrowShares(uint256 _amount, bool _roundUp) external view returns (uint256);
+
     function userBorrowShares(address) external view returns (uint256);
 
     function userCollateralBalance(address) external view returns (uint256);

--- a/src/modules/adaptors/Frax/CollateralFTokenAdaptor.sol
+++ b/src/modules/adaptors/Frax/CollateralFTokenAdaptor.sol
@@ -150,6 +150,11 @@ contract CollateralFTokenAdaptor is BaseAdaptor, FraxlendHealthFactorLogic {
      */
     function removeCollateral(uint256 _collateralAmount, IFToken _fraxlendPair) public {
         _validateFToken(_fraxlendPair);
+
+        if (_collateralAmount == type(uint256).max) {
+            _collateralAmount = _userCollateralBalance(_fraxlendPair, address(this));
+        }
+
         // remove collateral
         _removeCollateral(_collateralAmount, _fraxlendPair);
         uint256 _exchangeRate = _getExchangeRateInfo(_fraxlendPair); // needed to calculate LTV

--- a/src/modules/adaptors/Frax/DebtFTokenAdaptor.sol
+++ b/src/modules/adaptors/Frax/DebtFTokenAdaptor.sol
@@ -167,7 +167,7 @@ contract DebtFTokenAdaptor is BaseAdaptor, FraxlendHealthFactorLogic {
         _validateFToken(_fraxlendPair);
         ERC20 tokenToRepay = ERC20(_fraxlendPairAsset(_fraxlendPair));
         uint256 debtTokenToRepay = _maxAvailable(tokenToRepay, _debtTokenRepayAmount);
-        uint256 sharesToRepay = _toAssetShares(_fraxlendPair, debtTokenToRepay, false, true);
+        uint256 sharesToRepay = _toBorrowShares(_fraxlendPair, debtTokenToRepay, false, true);
         uint256 sharesAccToFraxlend = _userBorrowShares(_fraxlendPair, address(this)); // get fraxlendPair's record of borrowShares atm
         if (sharesAccToFraxlend == 0) revert DebtFTokenAdaptor__CannotRepayNoDebt(address(_fraxlendPair)); // NOTE: from checking it out, unless `userBorrowShares[_borrower] -= _shares;` reverts, then fraxlendCore lets users repay FRAX w/ no limiters.
 
@@ -250,21 +250,21 @@ contract DebtFTokenAdaptor is BaseAdaptor, FraxlendHealthFactorLogic {
     }
 
     /**
-     * @notice Converts a given asset amount to a number of asset shares (fTokens) from specified 'v2' Fraxlend Pair
-     * @dev This is one of the adjusted functions from v1 to v2. ftoken.toAssetShares() calls into the respective version (v2 by default) of Fraxlend Pair
+     * @notice Converts a given asset amount to a number of borrow shares from specified 'v2' Fraxlend Pair
+     * @dev This is one of the adjusted functions from v1 to v2. ftoken.toBorrowAmount() calls into the respective version (v2 by default) of Fraxlend Pair
      * @param fToken The specified Fraxlend Pair
      * @param amount The amount of asset
      * @param roundUp Whether to round up after division
      * @param previewInterest Whether to preview interest accrual before calculation
-     * @return number of asset shares
+     * @return number of borrow shares
      */
-    function _toAssetShares(
+    function _toBorrowShares(
         IFToken fToken,
         uint256 amount,
         bool roundUp,
         bool previewInterest
     ) internal view virtual returns (uint256) {
-        return fToken.toAssetShares(amount, roundUp, previewInterest);
+        return fToken.toBorrowShares(amount, roundUp, previewInterest);
     }
 
     /**

--- a/src/modules/adaptors/Frax/DebtFTokenAdaptorV1.sol
+++ b/src/modules/adaptors/Frax/DebtFTokenAdaptorV1.sol
@@ -88,20 +88,20 @@ contract DebtFTokenAdaptorV1 is DebtFTokenAdaptor {
     }
 
     /**
-     * @notice Converts a given asset amount to a number of asset shares (fTokens) from specified FraxlendV1 Pair
+     * @notice Converts a given asset amount to a number of borrow shares from specified FraxlendV1 Pair
      * @dev versions of FraxLendPair do not have a fourth param whereas v2 does
      * @param fToken The specified FraxLendPair
      * @param amount The amount of asset
      * @param roundUp Whether to round up after division
-     * @return number of asset shares
+     * @return number of borrow shares
      */
-    function _toAssetShares(
+    function _toBorrowShares(
         IFToken fToken,
         uint256 amount,
         bool roundUp,
         bool
     ) internal view override returns (uint256) {
-        return fToken.toAssetShares(amount, roundUp);
+        return fToken.toBorrowShares(amount, roundUp);
     }
 
     /**

--- a/test/testAdaptors/FraxlendCollateralAndDebtV1.t.sol
+++ b/test/testAdaptors/FraxlendCollateralAndDebtV1.t.sol
@@ -14,6 +14,7 @@ import "test/resources/MainnetStarter.t.sol";
  * @notice Test provision of collateral and borrowing on Fraxlend v1 pairs
  * @author 0xEinCodes, crispymangoes
  * @dev These are applied to FraxlendV1 Pair types and are the same tests carried out for FraxlendV1 pairs and the respective debt and collateral adaptors.
+ * @dev test with blocknumber = 18414005 bc of fraxlend pair conditions at this block otherwise modify fuzz test limits
  */
 contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHelperFunctions {
     using SafeTransferLib for ERC20;
@@ -277,9 +278,8 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // test taking loan w/ providing collateral to the wrong pair
-    function testTakingOutLoanInUntrackedPositionV1() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testTakingOutLoanInUntrackedPositionV1(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
         initialAssets = cellar.totalAssets();
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -299,9 +299,8 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
         cellar.callOnAdaptor(data);
     }
 
-    function testRepayingLoans() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testRepayingLoans(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
         initialAssets = cellar.totalAssets();
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -339,7 +338,7 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // okay just seeing if we can handle multiple fraxlend positions
-    // TODO: EIN - Reformat adaptorCall var names and troubleshoot why cvxFraxToBorrow has to be 1e18 right now
+    // TODO: EIN - Reformat adaptorCall var names and troubleshoot why cvxFraxToBorrow has to be 1e18 right now --> Theory: it has to do with the CVX pricing in the cellars?
     function testMultipleFraxlendPositions() external {
         uint256 assets = 1e18;
 
@@ -508,9 +507,8 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // Test removal of collateral but with taking a loan out and repaying it in full first. Also tests type(uint256).max with removeCollateral.
-    function testRemoveCollateralWithTypeUINT256MaxAfterRepay() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testRemoveCollateralWithTypeUINT256MaxAfterRepay(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
         initialAssets = cellar.totalAssets();
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -607,9 +605,8 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
         cellar.callOnAdaptor(data);
     }
 
-    function testLTV() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testLTV(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
         initialAssets = cellar.totalAssets();
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -655,9 +652,8 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // TODO: CRISPY - please take a look at the fuzzing, was having issues with this.
-    function testRepayPartialDebt() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testRepayPartialDebt(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
         initialAssets = cellar.totalAssets();
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -694,7 +690,9 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // This check stops strategists from taking on any debt in positions they do not set up properly.
-    function testLoanInUntrackedPosition() external {
+    function testLoanInUntrackedPosition(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
+
         uint32 fraxlendCollateralCVXPosition = 1_000_007; // fralendV1
         registry.trustPosition(
             fraxlendCollateralCVXPosition,
@@ -704,7 +702,6 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
         // purposely do not trust a fraxlendDebtCVXPosition
         cellar.addPositionToCatalogue(fraxlendCollateralCVXPosition);
         cellar.addPosition(5, fraxlendCollateralCVXPosition, abi.encode(0), false);
-        uint256 assets = 100_000e18;
         uint256 cvxFraxToBorrow = priceRouter.getValue(CVX, assets / 2, FRAX);
 
         deal(address(CVX), address(cellar), assets);
@@ -730,8 +727,9 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // have strategist call repay function when no debt owed. Expect revert.
-    function testRepayingDebtThatIsNotOwed() external {
-        uint256 assets = 100_000e18;
+    function testRepayingDebtThatIsNotOwed(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
+
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this));
         Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](1);
@@ -748,8 +746,8 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
     }
 
     // externalReceiver triggers when doing Strategist Function calls via adaptorCall.
-    function testBlockExternalReceiver() external {
-        uint256 assets = 100_000e18;
+    function testBlockExternalReceiver(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100_000e18);
         deal(address(CRV), address(this), assets);
         cellar.deposit(assets, address(this)); // holding position == collateralPosition w/ CRV FraxlendPair
         // Strategist tries to withdraw USDC to their own wallet using Adaptor's `withdraw` function.

--- a/test/testAdaptors/FraxlendCollateralAndDebtV2.t.sol
+++ b/test/testAdaptors/FraxlendCollateralAndDebtV2.t.sol
@@ -11,6 +11,7 @@ import "test/resources/MainnetStarter.t.sol";
 /**
  * @notice Test provision of collateral and borrowing on Fraxlend v2 pairs
  * @author 0xEinCodes, crispymangoes
+ * @dev test with blocknumber = 18414005 bc of fraxlend pair conditions at this block otherwise modify fuzz test limits
  */
 contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHelperFunctions {
     using SafeTransferLib for ERC20;
@@ -273,9 +274,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
     }
 
     // test taking loan w/ providing collateral to the wrong pair
-    function testTakingOutLoanInUntrackedPositionV2() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testTakingOutLoanInUntrackedPositionV2(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100e18);
         initialAssets = cellar.totalAssets();
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -295,9 +295,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
         cellar.callOnAdaptor(data);
     }
 
-    function testRepayingLoans() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testRepayingLoans(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100e18);
         initialAssets = cellar.totalAssets();
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -429,7 +428,7 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
     }
 
     function testRemoveCollateral(uint256 assets) external {
-        assets = bound(assets, 0.1e18, 100_000e18);
+        assets = bound(assets, 0.1e18, 100e18);
         initialAssets = cellar.totalAssets();
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -501,10 +500,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
     }
 
     // Test removal of collateral but with taking a loan out and repaying it in full first. Also tests type(uint256).max with removeCollateral.
-    // TODO: add stateless fuzzing, it is reverting when testing with 1000e18 for assets for example. Need to further investigate.
-    function testRemoveCollateralWithTypeUINT256MaxAfterRepay() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 100e18;
+    function testRemoveCollateralWithTypeUINT256MaxAfterRepay(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100e18);
         initialAssets = cellar.totalAssets();
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -601,9 +598,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
         cellar.callOnAdaptor(data);
     }
 
-    function testLTV() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testLTV(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100e18);
         initialAssets = cellar.totalAssets();
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -648,10 +644,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
         cellar.callOnAdaptor(data); // should transact now
     }
 
-    // TODO: CRISPY - please take a look at the fuzzing, was having issues with this.
-    function testRepayPartialDebt() external {
-        // assets = bound(assets, 0.1e18, 100_000e18);
-        uint256 assets = 1e18;
+    function testRepayPartialDebt(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 195e18);
         initialAssets = cellar.totalAssets();
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
@@ -688,7 +682,7 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
     }
 
     // This check stops strategists from taking on any debt in positions they do not set up properly.
-    function testLoanInUntrackedPosition() external {
+    function testLoanInUntrackedPosition(uint256 assets) external {
         uint32 fraxlendCollateralUNIPosition = 1_000_007; // fralendV2
         registry.trustPosition(
             fraxlendCollateralUNIPosition,
@@ -698,7 +692,7 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
         // purposely do not trust a fraxlendDebtUNIPosition
         cellar.addPositionToCatalogue(fraxlendCollateralUNIPosition);
         cellar.addPosition(5, fraxlendCollateralUNIPosition, abi.encode(0), false);
-        uint256 assets = 100_000e18;
+        assets = bound(assets, 0.1e18, 100e18);
         uint256 uniFraxToBorrow = priceRouter.getValue(UNI, assets / 2, FRAX);
 
         deal(address(UNI), address(cellar), assets);
@@ -721,8 +715,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
     }
 
     // have strategist call repay function when no debt owed. Expect revert.
-    function testRepayingDebtThatIsNotOwed() external {
-        uint256 assets = 100_000e18;
+    function testRepayingDebtThatIsNotOwed(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100e18);
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this));
         Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](1);
@@ -739,8 +733,8 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
     }
 
     // externalReceiver triggers when doing Strategist Function calls via adaptorCall.
-    function testBlockExternalReceiver() external {
-        uint256 assets = 100_000e18;
+    function testBlockExternalReceiver(uint256 assets) external {
+        assets = bound(assets, 0.1e18, 100e18);
         deal(address(MKR), address(this), assets);
         cellar.deposit(assets, address(this)); // holding position == collateralPosition w/ MKR FraxlendPair
         // Strategist tries to withdraw USDC to their own wallet using Adaptor's `withdraw` function.


### PR DESCRIPTION
## Core changes:

This PR encompasses small adjustments that were requested from strategists after initial deployment and further assessment of the Fraxlend adaptors developed this year.  It revolves around the development and testing features such as:

1. Changing logic within repay function in debt adaptors to use `toBorrowShares()` logic from Fraxlend logic instead to `toAssetShares()`.
2. Add `_maxAvailable()` style logic to the `removeCollateral()` function within `CollateralAdaptors`.

## TODOs:

- [x] Make code changes
- [x] Test code
- [x] PR Review
- [x] Finalize


