### PR TITLE
Feat/illiquid erc20

### DIFF
--- a/test/Cellar.t.sol
+++ b/test/Cellar.t.sol
@@ -96,19 +96,19 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        usdcCLR = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        usdcCLR = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
         vm.label(address(usdcCLR), "usdcCLR");
 
         cellarName = "Dummy Cellar V0.1";
         initialDeposit = 1e12;
         platformCut = 0.75e18;
-        wethCLR = _createCellar(cellarName, WETH, wethPosition, abi.encode(0), initialDeposit, platformCut);
+        wethCLR = _createCellar(cellarName, WETH, wethPosition, abi.encode(true), initialDeposit, platformCut);
         vm.label(address(wethCLR), "wethCLR");
 
         cellarName = "Dummy Cellar V0.2";
         initialDeposit = 1e4;
         platformCut = 0.75e18;
-        wbtcCLR = _createCellar(cellarName, WBTC, wbtcPosition, abi.encode(0), initialDeposit, platformCut);
+        wbtcCLR = _createCellar(cellarName, WBTC, wbtcPosition, abi.encode(true), initialDeposit, platformCut);
         vm.label(address(wbtcCLR), "wbtcCLR");
 
         // Add Cellar Positions to the registry.
@@ -119,7 +119,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         cellarName = "Cellar V0.0";
         initialDeposit = 1e6;
         platformCut = 0.75e18;
-        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         // Set up remaining cellar positions.
         cellar.addPositionToCatalogue(usdcCLRPosition);
@@ -129,9 +129,9 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         cellar.addPositionToCatalogue(wbtcCLRPosition);
         cellar.addPosition(3, wbtcCLRPosition, abi.encode(true), false);
         cellar.addPositionToCatalogue(wethPosition);
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
         cellar.addPositionToCatalogue(wbtcPosition);
-        cellar.addPosition(5, wbtcPosition, abi.encode(0), false);
+        cellar.addPosition(5, wbtcPosition, abi.encode(true), false);
         cellar.addAdaptorToCatalogue(address(cellarAdaptor));
         cellar.addPositionToCatalogue(usdtPosition);
 
@@ -309,7 +309,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         string memory cellarName = "Dummy Cellar V0.3";
         uint256 initialDeposit = 1e12;
         uint64 platformCut = 0.75e18;
-        Cellar wethVault = _createCellar(cellarName, WETH, wethPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar wethVault = _createCellar(cellarName, WETH, wethPosition, abi.encode(true), initialDeposit, platformCut);
 
         uint32 newWETHPosition = 10;
         registry.trustPosition(newWETHPosition, address(cellarAdaptor), abi.encode(wethVault));
@@ -406,11 +406,11 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         // Cellar should not be able to add position to tracked array until it is in the catalogue.
         vm.expectRevert(bytes(abi.encodeWithSelector(Cellar.Cellar__PositionNotInCatalogue.selector, wethPosition)));
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
 
         // Since WETH position is trusted, cellar should be able to add it to the catalogue, and to the tracked array.
         cellar.addPositionToCatalogue(wethPosition);
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
 
         // Registry distrusts weth position.
         registry.distrustPosition(wethPosition);
@@ -423,7 +423,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         // If strategist tries adding it back it reverts.
         vm.expectRevert(bytes(abi.encodeWithSelector(Registry.Registry__PositionIsNotTrusted.selector, wethPosition)));
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
 
         // Governance removes position from cellars catalogue.
         cellar.removePositionFromCatalogue(wethPosition); // Removes WETH position from catalogue.
@@ -482,10 +482,10 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         assertEq(zeroAddressAdaptor, address(0), "Removing position should have deleted position data.");
         // Check that adding a credit position as debt reverts.
         vm.expectRevert(bytes(abi.encodeWithSelector(Cellar.Cellar__DebtMismatch.selector, wethPosition)));
-        cellar.addPosition(4, wethPosition, abi.encode(0), true);
+        cellar.addPosition(4, wethPosition, abi.encode(true), true);
 
         // Check that `addPosition` actually adds it.
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
 
         assertEq(
             positionLength,
@@ -498,7 +498,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         // Check that `addPosition` reverts if position is already used.
         vm.expectRevert(bytes(abi.encodeWithSelector(Cellar.Cellar__PositionAlreadyUsed.selector, wethPosition)));
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
 
         // Give Cellar 1 wei of WETH.
         deal(address(WETH), address(cellar), 1);
@@ -517,7 +517,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         // Check that `addPosition` reverts if position is not trusted.
         vm.expectRevert(bytes(abi.encodeWithSelector(Cellar.Cellar__PositionNotInCatalogue.selector, 0)));
-        cellar.addPosition(4, 0, abi.encode(0), false);
+        cellar.addPosition(4, 0, abi.encode(true), false);
 
         // Check that `addPosition` reverts if debt position is not trusted.
         vm.expectRevert(bytes(abi.encodeWithSelector(Cellar.Cellar__PositionNotInCatalogue.selector, 0)));
@@ -529,13 +529,13 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         cellar.removePosition(4, false);
 
         // Check that addPosition sets position data.
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
         (address adaptor, bool isDebt, bytes memory adaptorData, bytes memory configurationData) = cellar
             .getPositionData(wethPosition);
         assertEq(adaptor, address(erc20Adaptor), "Adaptor should be the ERC20 adaptor.");
         assertTrue(!isDebt, "Position should not be debt.");
         assertEq(adaptorData, abi.encode((WETH)), "Adaptor data should be abi encoded WETH.");
-        assertEq(configurationData, abi.encode(0), "Configuration data should be abi encoded ZERO.");
+        assertEq(configurationData, abi.encode(true), "Configuration data should be abi encoded ZERO.");
 
         // Check that `swapPosition` works as expected.
         cellar.swapPositions(4, 2, false);
@@ -957,7 +957,14 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        Cellar debtCellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar debtCellar = _createCellar(
+            cellarName,
+            USDC,
+            usdcPosition,
+            abi.encode(true),
+            initialDeposit,
+            platformCut
+        );
 
         debtCellar.addPositionToCatalogue(debtWethPosition);
         debtCellar.addPositionToCatalogue(debtWbtcPosition);
@@ -1006,7 +1013,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         string memory cellarName = "Cellar B V0.0";
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
-        Cellar cellarB = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar cellarB = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         uint32 cellarBPosition = 10;
         registry.trustPosition(cellarBPosition, address(cellarAdaptor), abi.encode(cellarB));
@@ -1015,7 +1022,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         cellarName = "Cellar A V0.0";
         initialDeposit = 1e6;
         platformCut = 0.75e18;
-        Cellar cellarA = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar cellarA = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         cellarA.addPositionToCatalogue(cellarBPosition);
         cellarA.addPosition(0, cellarBPosition, abi.encode(true), false);
@@ -1082,7 +1089,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         // Governance can remove it itself by calling `distrustPosition`.
 
         // Add asset that will be depegged.
-        cellar.addPosition(5, usdtPosition, abi.encode(0), false);
+        cellar.addPosition(5, usdtPosition, abi.encode(true), false);
 
         deal(address(USDC), address(this), 200e6);
         cellar.deposit(100e6, address(this));
@@ -1100,7 +1107,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         // it.
 
         // Add asset that will be depegged.
-        cellar.addPosition(5, usdtPosition, abi.encode(0), false);
+        cellar.addPosition(5, usdtPosition, abi.encode(true), false);
 
         deal(address(USDC), address(this), 200e6);
         cellar.deposit(100e6, address(this));
@@ -1169,7 +1176,7 @@ contract CellarTest is MainnetStarterTest, AdaptorHelperFunctions {
         // safety contract, shutdown old cellar, and allow users to withdraw
         // from the safety contract.
 
-        cellar.addPosition(5, usdtPosition, abi.encode(0), false);
+        cellar.addPosition(5, usdtPosition, abi.encode(true), false);
 
         deal(address(USDC), address(this), 100e6);
         cellar.deposit(100e6, address(this));

--- a/test/CellarWithERC4626Adaptor.t.sol
+++ b/test/CellarWithERC4626Adaptor.t.sol
@@ -98,19 +98,19 @@ contract CellarWithERC4626AdaptorTest is MainnetStarterTest, AdaptorHelperFuncti
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        usdcCLR = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        usdcCLR = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
         vm.label(address(usdcCLR), "usdcCLR");
 
         cellarName = "Dummy Cellar V0.1";
         initialDeposit = 1e12;
         platformCut = 0.75e18;
-        wethCLR = _createCellar(cellarName, WETH, wethPosition, abi.encode(0), initialDeposit, platformCut);
+        wethCLR = _createCellar(cellarName, WETH, wethPosition, abi.encode(true), initialDeposit, platformCut);
         vm.label(address(wethCLR), "wethCLR");
 
         cellarName = "Dummy Cellar V0.2";
         initialDeposit = 1e4;
         platformCut = 0.75e18;
-        wbtcCLR = _createCellar(cellarName, WBTC, wbtcPosition, abi.encode(0), initialDeposit, platformCut);
+        wbtcCLR = _createCellar(cellarName, WBTC, wbtcPosition, abi.encode(true), initialDeposit, platformCut);
         vm.label(address(wbtcCLR), "wbtcCLR");
 
         // Add Cellar Positions to the registry.
@@ -121,7 +121,7 @@ contract CellarWithERC4626AdaptorTest is MainnetStarterTest, AdaptorHelperFuncti
         cellarName = "Cellar V0.0";
         initialDeposit = 1e6;
         platformCut = 0.75e18;
-        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         // Set up remaining cellar positions.
         cellar.addPositionToCatalogue(usdcCLRPosition);
@@ -131,9 +131,9 @@ contract CellarWithERC4626AdaptorTest is MainnetStarterTest, AdaptorHelperFuncti
         cellar.addPositionToCatalogue(wbtcCLRPosition);
         cellar.addPosition(3, wbtcCLRPosition, abi.encode(true), false);
         cellar.addPositionToCatalogue(wethPosition);
-        cellar.addPosition(4, wethPosition, abi.encode(0), false);
+        cellar.addPosition(4, wethPosition, abi.encode(true), false);
         cellar.addPositionToCatalogue(wbtcPosition);
-        cellar.addPosition(5, wbtcPosition, abi.encode(0), false);
+        cellar.addPosition(5, wbtcPosition, abi.encode(true), false);
         cellar.addAdaptorToCatalogue(address(erc4626Adaptor));
         cellar.addPositionToCatalogue(usdtPosition);
 
@@ -204,7 +204,7 @@ contract CellarWithERC4626AdaptorTest is MainnetStarterTest, AdaptorHelperFuncti
         string memory cellarName = "Cellar B V0.0";
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
-        Cellar cellarB = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar cellarB = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         uint32 cellarBPosition = 10;
         registry.trustPosition(cellarBPosition, address(erc4626Adaptor), abi.encode(cellarB));
@@ -213,7 +213,7 @@ contract CellarWithERC4626AdaptorTest is MainnetStarterTest, AdaptorHelperFuncti
         cellarName = "Cellar A V0.0";
         initialDeposit = 1e6;
         platformCut = 0.75e18;
-        Cellar cellarA = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar cellarA = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         cellarA.addPositionToCatalogue(cellarBPosition);
         cellarA.addPosition(0, cellarBPosition, abi.encode(true), false);
@@ -263,7 +263,14 @@ contract CellarWithERC4626AdaptorTest is MainnetStarterTest, AdaptorHelperFuncti
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        Cellar metaCellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar metaCellar = _createCellar(
+            cellarName,
+            USDC,
+            usdcPosition,
+            abi.encode(true),
+            initialDeposit,
+            platformCut
+        );
         initialAssets = metaCellar.totalAssets();
 
         metaCellar.addPositionToCatalogue(cellarPosition);

--- a/test/CellarWithOracle.t.sol
+++ b/test/CellarWithOracle.t.sol
@@ -86,7 +86,7 @@ contract CellarWithOracleTest is MainnetStarterTest, AdaptorHelperFunctions {
             cellarName,
             cellarName,
             usdcPosition,
-            abi.encode(0),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max
@@ -393,9 +393,9 @@ contract CellarWithOracleTest is MainnetStarterTest, AdaptorHelperFunctions {
         depositGas1Asset -= gasleft();
 
         // Rebalance Cellar so it has assets in 4 positions.
-        cellar.addPosition(1, usdtPosition, abi.encode(0), false);
-        cellar.addPosition(2, daiPosition, abi.encode(0), false);
-        cellar.addPosition(3, fraxPosition, abi.encode(0), false);
+        cellar.addPosition(1, usdtPosition, abi.encode(true), false);
+        cellar.addPosition(2, daiPosition, abi.encode(true), false);
+        cellar.addPosition(3, fraxPosition, abi.encode(true), false);
 
         uint256 usdcAmount = (2 * assets) / 4;
         uint256 usdtAmount = priceRouter.getValue(USDC, usdcAmount, USDT);
@@ -553,7 +553,7 @@ contract CellarWithOracleTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         // Strategist can still manage the cellar.
         cellar.setRebalanceDeviation(0.01e18);
-        cellar.addPosition(1, usdtPosition, abi.encode(0), false);
+        cellar.addPosition(1, usdtPosition, abi.encode(true), false);
         cellar.addAdaptorToCatalogue(address(swapWithUniswapAdaptor));
         Cellar.AdaptorCall[] memory data = new Cellar.AdaptorCall[](1);
         bytes[] memory adaptorCalls = new bytes[](1);

--- a/test/CellarWithShareLockPeriod.t.sol
+++ b/test/CellarWithShareLockPeriod.t.sol
@@ -90,7 +90,7 @@ contract CellarWithShareLockPeriodTest is MainnetStarterTest, AdaptorHelperFunct
             cellarName,
             cellarName,
             usdcPosition,
-            abi.encode(0),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max
@@ -100,9 +100,9 @@ contract CellarWithShareLockPeriodTest is MainnetStarterTest, AdaptorHelperFunct
 
         // Set up remaining cellar positions.
         cellar.addPositionToCatalogue(wethPosition);
-        cellar.addPosition(1, wethPosition, abi.encode(0), false);
+        cellar.addPosition(1, wethPosition, abi.encode(true), false);
         cellar.addPositionToCatalogue(wbtcPosition);
-        cellar.addPosition(2, wbtcPosition, abi.encode(0), false);
+        cellar.addPosition(2, wbtcPosition, abi.encode(true), false);
 
         cellar.setStrategistPayoutAddress(strategist);
 
@@ -213,7 +213,7 @@ contract CellarWithShareLockPeriodTest is MainnetStarterTest, AdaptorHelperFunct
             cellarName,
             cellarName,
             usdcPosition,
-            abi.encode(0),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max
@@ -224,7 +224,7 @@ contract CellarWithShareLockPeriodTest is MainnetStarterTest, AdaptorHelperFunct
         );
 
         cellarA.addPositionToCatalogue(wethPosition);
-        cellarA.addPosition(1, wethPosition, abi.encode(0), false);
+        cellarA.addPosition(1, wethPosition, abi.encode(true), false);
 
         // Set up worst case scenario where
         // Cellar has all of its funds in mispriced asset(WETH)

--- a/test/ERC4626SharePriceOracle/ERC4626SharePriceOracle.t.sol
+++ b/test/ERC4626SharePriceOracle/ERC4626SharePriceOracle.t.sol
@@ -83,7 +83,7 @@ contract ERC4626SharePriceOracleTest is MainnetStarterTest, AdaptorHelperFunctio
         cellar.addAdaptorToCatalogue(address(aaveATokenAdaptor));
 
         cellar.addPositionToCatalogue(usdcPosition);
-        cellar.addPosition(1, usdcPosition, abi.encode(0), false);
+        cellar.addPosition(1, usdcPosition, abi.encode(true), false);
 
         USDC.safeApprove(address(cellar), type(uint256).max);
 
@@ -1011,7 +1011,7 @@ contract ERC4626SharePriceOracleTest is MainnetStarterTest, AdaptorHelperFunctio
         string memory cellarName = "WETH Cellar V0.0";
         uint64 platformCut = 0.75e18;
 
-        cellar = _createCellar(cellarName, WETH, wethPosition, abi.encode(0), assets, platformCut);
+        cellar = _createCellar(cellarName, WETH, wethPosition, abi.encode(true), assets, platformCut);
 
         // Create new share price oracle for it.
         {

--- a/test/WithdrawQueue.t.sol
+++ b/test/WithdrawQueue.t.sol
@@ -72,7 +72,7 @@ contract WithdrawQueueTest is MainnetStarterTest, AdaptorHelperFunctions, ISolve
             cellarName,
             cellarName,
             usdcPosition,
-            abi.encode(0),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max

--- a/test/testAdaptors/AaveV2Morpho.t.sol
+++ b/test/testAdaptors/AaveV2Morpho.t.sol
@@ -78,7 +78,7 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 initialDeposit = 1e12;
         uint64 platformCut = 0.75e18;
 
-        cellar = _createCellar(cellarName, WETH, morphoAWethPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, WETH, morphoAWethPosition, abi.encode(true), initialDeposit, platformCut);
 
         cellar.addAdaptorToCatalogue(address(aTokenAdaptor));
         cellar.addAdaptorToCatalogue(address(debtTokenAdaptor));
@@ -223,7 +223,7 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         uint256 assetsWithdrawable;
         // Add vanilla WETH to the cellar.
-        cellar.addPosition(0, wethPosition, abi.encode(0), false);
+        cellar.addPosition(0, wethPosition, abi.encode(true), false);
         // Add debt position to cellar.
         cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
 
@@ -393,7 +393,7 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
         cellar.addAdaptorToCatalogue(address(aTokenAdaptor));
         cellar.addAdaptorToCatalogue(address(swapWithUniswapAdaptor));
         cellar.addPositionToCatalogue(usdcPosition);
-        cellar.addPosition(0, usdcPosition, abi.encode(0), false);
+        cellar.addPosition(0, usdcPosition, abi.encode(true), false);
 
         // assets = 100_000e6;
         assets = bound(assets, 1e6, 1_000_000e6);
@@ -466,8 +466,8 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
         // Setup cellar so that aSTETH is illiquid.
         // Then have strategist loop into STETH.
         // -Deposit STETH as collateral, and borrow WETH, repeat.
-        cellar.addPosition(0, wethPosition, abi.encode(0), false);
-        cellar.addPosition(0, stethPosition, abi.encode(0), false);
+        cellar.addPosition(0, wethPosition, abi.encode(true), false);
+        cellar.addPosition(0, stethPosition, abi.encode(true), false);
         cellar.addPosition(0, morphoAStEthPosition, abi.encode(false), false);
         cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
 
@@ -539,7 +539,7 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
         assetsToBorrow = bound(assetsToBorrow, 1, 1_000e18);
 
         // Add vanilla WETH to the cellar.
-        cellar.addPosition(0, wethPosition, abi.encode(0), false);
+        cellar.addPosition(0, wethPosition, abi.encode(true), false);
         // Add debt position to cellar.
         cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
 
@@ -584,7 +584,7 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 assets = 100e18;
 
         // Add vanilla WETH to the cellar.
-        cellar.addPosition(0, wethPosition, abi.encode(0), false);
+        cellar.addPosition(0, wethPosition, abi.encode(true), false);
         // Add debt position to cellar.
         cellar.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
 
@@ -648,8 +648,8 @@ contract CellarAaveV2MorphoTest is MainnetStarterTest, AdaptorHelperFunctions {
 
     function _setupCellarForBorrowing(Cellar target) internal {
         // Add required positions.
-        target.addPosition(0, wethPosition, abi.encode(0), false);
-        target.addPosition(1, stethPosition, abi.encode(0), false);
+        target.addPosition(0, wethPosition, abi.encode(true), false);
+        target.addPosition(1, stethPosition, abi.encode(true), false);
         target.addPosition(2, morphoAStEthPosition, abi.encode(0), false);
         target.addPosition(0, morphoDebtWethPosition, abi.encode(0), true);
 

--- a/test/testAdaptors/CellarAdaptor.t.sol
+++ b/test/testAdaptors/CellarAdaptor.t.sol
@@ -55,7 +55,7 @@ contract CellarAdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         cellar.setRebalanceDeviation(0.01e18);
 
@@ -69,7 +69,14 @@ contract CellarAdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        Cellar metaCellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        Cellar metaCellar = _createCellar(
+            cellarName,
+            USDC,
+            usdcPosition,
+            abi.encode(true),
+            initialDeposit,
+            platformCut
+        );
         uint256 initialAssets = metaCellar.totalAssets();
 
         metaCellar.addPositionToCatalogue(cellarPosition);

--- a/test/testAdaptors/CurveAdaptor.t.sol
+++ b/test/testAdaptors/CurveAdaptor.t.sol
@@ -532,7 +532,7 @@ contract CurveAdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
             cellarName,
             cellarName,
             usdcPosition,
-            abi.encode(0),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max
@@ -1625,7 +1625,7 @@ contract CurveAdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
             cellarName,
             cellarName,
             usdcPosition,
-            abi.encode(0),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max

--- a/test/testAdaptors/ERC20Adaptor.t.sol
+++ b/test/testAdaptors/ERC20Adaptor.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+// Import Everything from Starter file.
+import "test/resources/MainnetStarter.t.sol";
+
+import { AdaptorHelperFunctions } from "test/resources/AdaptorHelperFunctions.sol";
+
+contract ERC20AdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
+    using SafeTransferLib for ERC20;
+    using Math for uint256;
+    using stdStorage for StdStorage;
+    using Address for address;
+
+    Cellar private cellar;
+
+    uint32 private usdcPosition = 1;
+    uint32 private wethPosition = 2;
+
+    uint256 initialAssets;
+
+    function setUp() external {
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 16921343;
+        _startFork(rpcKey, blockNumber);
+
+        // Run Starter setUp code.
+        _setUp();
+
+        PriceRouter.ChainlinkDerivativeStorage memory stor;
+
+        PriceRouter.AssetSettings memory settings;
+
+        uint256 price = uint256(IChainlinkAggregator(WETH_USD_FEED).latestAnswer());
+        settings = PriceRouter.AssetSettings(CHAINLINK_DERIVATIVE, WETH_USD_FEED);
+        priceRouter.addAsset(WETH, settings, abi.encode(stor), price);
+
+        price = uint256(IChainlinkAggregator(USDC_USD_FEED).latestAnswer());
+        settings = PriceRouter.AssetSettings(CHAINLINK_DERIVATIVE, USDC_USD_FEED);
+        priceRouter.addAsset(USDC, settings, abi.encode(stor), price);
+
+        // Setup Cellar:
+
+        registry.trustPosition(usdcPosition, address(erc20Adaptor), abi.encode(USDC));
+        registry.trustPosition(wethPosition, address(erc20Adaptor), abi.encode(WETH));
+
+        string memory cellarName = "ERC20 Cellar V0.0";
+        uint256 initialDeposit = 1e6;
+        uint64 platformCut = 0.75e18;
+
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
+
+        cellar.addPositionToCatalogue(wethPosition);
+
+        cellar.setRebalanceDeviation(0.01e18);
+
+        USDC.safeApprove(address(cellar), type(uint256).max);
+
+        initialAssets = cellar.totalAssets();
+    }
+
+    function testLogic(uint256 assets, uint256 illiquidMultiplier) external {
+        assets = bound(assets, 1e6, 1_000_000e6);
+        illiquidMultiplier = bound(illiquidMultiplier, 0, 1e18); // The percent of assets that are illiquid in the cellar.
+
+        // USDC is liquid, but WETH is not liquid.
+        cellar.addPosition(1, wethPosition, abi.encode(false), false);
+
+        // Have user deposit into cellar.
+        deal(address(USDC), address(this), assets);
+        cellar.deposit(assets, address(this));
+
+        uint256 totalAssets = cellar.totalAssets();
+        assertEq(totalAssets, assets + initialAssets, "All assets should be accounted for.");
+        // All assets should be liquid.
+        uint256 liquidAssets = cellar.totalAssetsWithdrawable();
+        assertEq(liquidAssets, totalAssets, "All assets should be liquid.");
+
+        // Simulate a strategist rebalance into WETH.
+        uint256 assetsIlliquid = assets.mulDivDown(illiquidMultiplier, 1e18);
+        uint256 assetsInWeth = priceRouter.getValue(USDC, assetsIlliquid, WETH);
+        deal(address(USDC), address(cellar), totalAssets - assetsIlliquid);
+        deal(address(WETH), address(cellar), assetsInWeth);
+
+        totalAssets = cellar.totalAssets();
+        assertApproxEqAbs(totalAssets, assets + initialAssets, 1, "Total assets should be the same.");
+
+        liquidAssets = cellar.totalAssetsWithdrawable();
+        assertApproxEqAbs(liquidAssets, totalAssets - assetsIlliquid, 1, "Cellar should only be partially liquid.");
+
+        // If for some reason a cellar tried to pull from the illiquid position it would revert.
+        bytes memory data = abi.encodeWithSelector(
+            ERC20Adaptor.withdraw.selector,
+            1,
+            address(this),
+            abi.encode(WETH),
+            abi.encode(false)
+        );
+
+        vm.startPrank(address(cellar));
+        vm.expectRevert(bytes(abi.encodeWithSelector(BaseAdaptor.BaseAdaptor__UserWithdrawsNotAllowed.selector)));
+        address(erc20Adaptor).functionDelegateCall(data);
+        vm.stopPrank();
+    }
+}

--- a/test/testAdaptors/FraxlendCollateralAndDebtV1.t.sol
+++ b/test/testAdaptors/FraxlendCollateralAndDebtV1.t.sol
@@ -149,7 +149,7 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
             cellarName,
             cellarName,
             crvPosition,
-            abi.encode(CRV),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max
@@ -166,10 +166,10 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
         cellar.addPositionToCatalogue(fraxPosition);
         cellar.addPositionToCatalogue(wbtcPosition);
 
-        cellar.addPosition(1, wethPosition, abi.encode(0), false);
+        cellar.addPosition(1, wethPosition, abi.encode(true), false);
         cellar.addPosition(2, fraxlendCollateralCRVPosition, abi.encode(0), false);
-        cellar.addPosition(3, fraxPosition, abi.encode(0), false);
-        cellar.addPosition(4, wbtcPosition, abi.encode(0), false);
+        cellar.addPosition(3, fraxPosition, abi.encode(true), false);
+        cellar.addPosition(4, wbtcPosition, abi.encode(true), false);
 
         cellar.addPosition(0, fraxlendDebtCRVPosition, abi.encode(0), true);
 
@@ -355,7 +355,7 @@ contract CellarFraxLendCollateralAndDebtTestV1 is MainnetStarterTest, AdaptorHel
         cellar.addPositionToCatalogue(fraxlendCollateralCVXPosition);
         cellar.addPositionToCatalogue(fraxlendDebtCVXPosition);
         cellar.addPosition(5, fraxlendCollateralCVXPosition, abi.encode(0), false);
-        cellar.addPosition(6, cvxPosition, abi.encode(0), false);
+        cellar.addPosition(6, cvxPosition, abi.encode(true), false);
         cellar.addPosition(1, fraxlendDebtCVXPosition, abi.encode(0), true);
 
         // multiple adaptor calls

--- a/test/testAdaptors/FraxlendCollateralAndDebtV2.t.sol
+++ b/test/testAdaptors/FraxlendCollateralAndDebtV2.t.sol
@@ -145,7 +145,7 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
             cellarName,
             cellarName,
             mkrPosition,
-            abi.encode(MKR),
+            abi.encode(true),
             initialDeposit,
             platformCut,
             type(uint192).max
@@ -162,10 +162,10 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
         cellar.addPositionToCatalogue(fraxPosition);
         cellar.addPositionToCatalogue(apePosition);
 
-        cellar.addPosition(1, wethPosition, abi.encode(0), false);
+        cellar.addPosition(1, wethPosition, abi.encode(true), false);
         cellar.addPosition(2, fraxlendCollateralMKRPosition, abi.encode(0), false);
-        cellar.addPosition(3, fraxPosition, abi.encode(0), false);
-        cellar.addPosition(4, apePosition, abi.encode(0), false);
+        cellar.addPosition(3, fraxPosition, abi.encode(true), false);
+        cellar.addPosition(4, apePosition, abi.encode(true), false);
 
         cellar.addPosition(0, fraxlendDebtMKRPosition, abi.encode(0), true);
 
@@ -351,7 +351,7 @@ contract CellarFraxLendCollateralAndDebtTestV2 is MainnetStarterTest, AdaptorHel
         cellar.addPositionToCatalogue(fraxlendCollateralUNIPosition);
         cellar.addPositionToCatalogue(fraxlendDebtUNIPosition);
         cellar.addPosition(5, fraxlendCollateralUNIPosition, abi.encode(0), false);
-        cellar.addPosition(6, uniPosition, abi.encode(0), false);
+        cellar.addPosition(6, uniPosition, abi.encode(true), false);
         cellar.addPosition(1, fraxlendDebtUNIPosition, abi.encode(0), true);
 
         // multiple adaptor calls

--- a/test/testAdaptors/LegacyCellarAdaptor.t.sol
+++ b/test/testAdaptors/LegacyCellarAdaptor.t.sol
@@ -57,7 +57,7 @@ contract LegacyCellarAdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         // Setup Share Price Oracle.
         ERC4626 _target = ERC4626(address(cellar));
@@ -102,7 +102,7 @@ contract LegacyCellarAdaptorTest is MainnetStarterTest, AdaptorHelperFunctions {
         initialDeposit = 1e6;
         platformCut = 0.75e18;
 
-        metaCellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        metaCellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         metaCellar.addAdaptorToCatalogue(address(cellarAdaptor));
         metaCellar.addPositionToCatalogue(cellarPosition);

--- a/test/testAdaptors/UniswapV3.t.sol
+++ b/test/testAdaptors/UniswapV3.t.sol
@@ -85,7 +85,7 @@ contract UniswapV3AdaptorTest is MainnetStarterTest, AdaptorHelperFunctions, ERC
         uint256 initialDeposit = 1e6;
         uint64 platformCut = 0.75e18;
 
-        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
 
         vm.label(address(cellar), "cellar");
         vm.label(strategist, "strategist");
@@ -95,10 +95,10 @@ contract UniswapV3AdaptorTest is MainnetStarterTest, AdaptorHelperFunctions, ERC
         cellar.addPositionToCatalogue(usdcDaiPosition);
         cellar.addPositionToCatalogue(usdcWethPosition);
 
-        cellar.addPosition(1, daiPosition, abi.encode(0), false);
-        cellar.addPosition(1, wethPosition, abi.encode(0), false);
-        cellar.addPosition(1, usdcDaiPosition, abi.encode(0), false);
-        cellar.addPosition(1, usdcWethPosition, abi.encode(0), false);
+        cellar.addPosition(1, daiPosition, abi.encode(true), false);
+        cellar.addPosition(1, wethPosition, abi.encode(true), false);
+        cellar.addPosition(1, usdcDaiPosition, abi.encode(true), false);
+        cellar.addPosition(1, usdcWethPosition, abi.encode(true), false);
 
         cellar.addAdaptorToCatalogue(address(uniswapV3Adaptor));
         cellar.addAdaptorToCatalogue(address(swapWithUniswapAdaptor));

--- a/test/testAdaptors/Vesting.t.sol
+++ b/test/testAdaptors/Vesting.t.sol
@@ -63,7 +63,7 @@ contract CellarVestingTest is MainnetStarterTest, AdaptorHelperFunctions {
         string memory cellarName = "Multiposition Cellar LP Token";
         uint64 platformCut = 0.75e18;
 
-        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(0), initialDeposit, platformCut);
+        cellar = _createCellar(cellarName, USDC, usdcPosition, abi.encode(true), initialDeposit, platformCut);
         cellar.addAdaptorToCatalogue(address(erc20Adaptor));
         cellar.addAdaptorToCatalogue(address(vestingAdaptor));
 


### PR DESCRIPTION
Small edit to the ERC20Adaptor that allows for strategist to set erc20 positions as illiquid, or liquid, when adding them to the cellar.