### PR TITLE
Feat/share ccip bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cache/
 out/
 broadcast/
+gnosisTxs/
 
 # Environment variables!
 .env

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,6 +29,3 @@
 [submodule "lib/pendle-core-v2-public"]
 	path = lib/pendle-core-v2-public
 	url = https://github.com/pendle-finance/pendle-core-v2-public
-[submodule "lib/ccip"]
-	path = lib/ccip
-	url = https://github.com/smartcontractkit/ccip

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "lib/pendle-core-v2-public"]
 	path = lib/pendle-core-v2-public
 	url = https://github.com/pendle-finance/pendle-core-v2-public
+[submodule "lib/ccip"]
+	path = lib/ccip
+	url = https://github.com/smartcontractkit/ccip

--- a/remappings.txt
+++ b/remappings.txt
@@ -9,3 +9,4 @@ ds-test/=lib/forge-std/lib/ds-test/src/
 @uniswapV3P=lib/v3-periphery/contracts/
 @uniswapV3C=lib/v3-core/contracts/
 @balancer=lib/balancer-v2-monorepo/pkg
+@ccip=lib/ccip/

--- a/src/mocks/MockCCIPRouter.sol
+++ b/src/mocks/MockCCIPRouter.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import { Client } from "@ccip/contracts/src/v0.8/ccip/libraries/Client.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+
+contract MockCCIPRouter {
+    ERC20 public immutable LINK;
+
+    constructor(address _link) {
+        LINK = ERC20(_link);
+    }
+
+    uint256 public messageCount;
+
+    uint256 public currentFee = 1e18;
+
+    uint64 public constant SOURCE_SELECTOR = 6101244977088475029;
+    uint64 public constant DESTINATION_SELECTOR = 16015286601757825753;
+
+    mapping(bytes32 => Client.Any2EVMMessage) public messages;
+
+    bytes32 public lastMessageId;
+
+    function setFee(uint256 newFee) external {
+        currentFee = newFee;
+    }
+
+    function getLastMessage() external view returns (Client.Any2EVMMessage memory) {
+        return messages[lastMessageId];
+    }
+
+    function getFee(uint64, Client.EVM2AnyMessage memory) external view returns (uint256) {
+        return currentFee;
+    }
+
+    function ccipSend(uint64 chainSelector, Client.EVM2AnyMessage memory message) external returns (bytes32 messageId) {
+        LINK.transferFrom(msg.sender, address(this), currentFee);
+        messageId = bytes32(messageCount);
+        messageCount++;
+        lastMessageId = messageId;
+        messages[messageId].messageId = messageId;
+        messages[messageId].sourceChainSelector = chainSelector == SOURCE_SELECTOR
+            ? DESTINATION_SELECTOR
+            : SOURCE_SELECTOR;
+        messages[messageId].sender = abi.encode(msg.sender);
+        messages[messageId].data = message.data;
+    }
+}

--- a/src/modules/multi-chain-share/DestinationMinter.sol
+++ b/src/modules/multi-chain-share/DestinationMinter.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { CCIPReceiver } from "@ccip/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol";
+import { Client } from "@ccip/contracts/src/v0.8/ccip/libraries/Client.sol";
+import { IRouterClient } from "@ccip/contracts/src/v0.8/ccip/interfaces/IRouterClient.sol";
+
+/**
+ * @title DestinationMinter
+ * @notice Receives CCIP messages from SourceLocker, to mint ERC20 shares that
+ *         represent ERC4626 shares locked on source chain.
+ * @author crispymangoes
+ */
+contract DestinationMinter is ERC20, CCIPReceiver {
+    using SafeTransferLib for ERC20;
+
+    //============================== ERRORS ===============================
+
+    error DestinationMinter___SourceChainNotAllowlisted(uint64 sourceChainSelector);
+    error DestinationMinter___SenderNotAllowlisted(address sender);
+    error DestinationMinter___InvalidTo();
+    error DestinationMinter___FeeTooHigh();
+
+    //============================== EVENTS ===============================
+
+    event BridgeToSource(uint256 amount, address to);
+    event BridgeFromSource(uint256 amount, address to);
+
+    //============================== MODIFIERS ===============================
+
+    modifier onlyAllowlisted(uint64 _sourceChainSelector, address _sender) {
+        if (_sourceChainSelector != sourceChainSelector)
+            revert DestinationMinter___SourceChainNotAllowlisted(_sourceChainSelector);
+        if (_sender != targetSource) revert DestinationMinter___SenderNotAllowlisted(_sender);
+        _;
+    }
+
+    //============================== IMMUTABLES ===============================
+
+    /**
+     * @notice The address of the SourceLocker on source chain.
+     */
+    address public immutable targetSource;
+
+    /**
+     * @notice The CCIP source chain selector.
+     */
+    uint64 public immutable sourceChainSelector;
+
+    /**
+     * @notice The CCIP destination chain selector.
+     */
+    uint64 public immutable destinationChainSelector;
+
+    /**
+     * @notice This networks LINK contract.
+     */
+    ERC20 public immutable LINK;
+
+    /**
+     * @notice The message gas limit to use for CCIP messages.
+     */
+    uint256 public immutable messageGasLimit;
+
+    constructor(
+        address _router,
+        address _targetSource,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals,
+        uint64 _sourceChainSelector,
+        uint64 _destinationChainSelector,
+        address _link,
+        uint256 _messageGasLimit
+    ) ERC20(_name, _symbol, _decimals) CCIPReceiver(_router) {
+        targetSource = _targetSource;
+        sourceChainSelector = _sourceChainSelector;
+        destinationChainSelector = _destinationChainSelector;
+        LINK = ERC20(_link);
+        messageGasLimit = _messageGasLimit;
+    }
+
+    //============================== BRIDGE ===============================
+
+    /**
+     * @notice Bridge shares back to source chain.
+     */
+    function bridgeToSource(uint256 amount, address to, uint256 maxLinkToPay) external returns (bytes32 messageId) {
+        if (to == address(0)) revert DestinationMinter___InvalidTo();
+        _burn(msg.sender, amount);
+
+        Client.EVM2AnyMessage memory message = _buildMessage(amount, to);
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        uint256 fees = router.getFee(sourceChainSelector, message);
+
+        if (fees > maxLinkToPay) revert DestinationMinter___FeeTooHigh();
+
+        LINK.safeTransferFrom(msg.sender, address(this), fees);
+
+        LINK.safeApprove(address(router), fees);
+
+        messageId = router.ccipSend(sourceChainSelector, message);
+        emit BridgeToSource(amount, to);
+    }
+
+    //============================== VIEW FUNCTIONS ===============================
+
+    /**
+     * @notice Preview fee required to bridge shares back to source.
+     */
+    function previewFee(uint256 amount, address to) public view returns (uint256 fee) {
+        Client.EVM2AnyMessage memory message = _buildMessage(amount, to);
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        fee = router.getFee(sourceChainSelector, message);
+    }
+
+    //============================== CCIP RECEIVER ===============================
+
+    /**
+     * @notice Implement internal _ccipRecevie function logic.
+     */
+    function _ccipReceive(
+        Client.Any2EVMMessage memory any2EvmMessage
+    )
+        internal
+        override
+        onlyAllowlisted(any2EvmMessage.sourceChainSelector, abi.decode(any2EvmMessage.sender, (address)))
+    {
+        (uint256 amount, address to) = abi.decode(any2EvmMessage.data, (uint256, address));
+        _mint(to, amount);
+        emit BridgeFromSource(amount, to);
+    }
+
+    //============================== INTERNAL HELPER ===============================
+
+    /**
+     * @notice Build the CCIP message to send to source locker.
+     */
+    function _buildMessage(uint256 amount, address to) internal view returns (Client.EVM2AnyMessage memory message) {
+        message = Client.EVM2AnyMessage({
+            receiver: abi.encode(targetSource),
+            data: abi.encode(amount, to),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: Client._argsToBytes(
+                // Additional arguments, setting gas limit and non-strict sequencing mode
+                Client.EVMExtraArgsV1({ gasLimit: messageGasLimit /*, strict: false*/ })
+            ),
+            feeToken: address(LINK)
+        });
+    }
+}

--- a/src/modules/multi-chain-share/DestinationMinter.sol
+++ b/src/modules/multi-chain-share/DestinationMinter.sol
@@ -86,6 +86,10 @@ contract DestinationMinter is ERC20, CCIPReceiver {
 
     /**
      * @notice Bridge shares back to source chain.
+     * @param amount Number of shares to burn on destination network and unlock/transfer on source network.
+     * @param to Specified address to burn destination network `share` tokens, and receive unlocked `share` tokens on source network.
+     * @param maxLinkToPay Specified max amount of LINK fees to pay as per this contract.
+     * @return messageId Resultant CCIP messageId.
      */
     function bridgeToSource(uint256 amount, address to, uint256 maxLinkToPay) external returns (bytes32 messageId) {
         if (to == address(0)) revert DestinationMinter___InvalidTo();
@@ -111,6 +115,9 @@ contract DestinationMinter is ERC20, CCIPReceiver {
 
     /**
      * @notice Preview fee required to bridge shares back to source.
+     * @param amount Specified amount of `share` tokens to bridge to source network.
+     * @param to Specified address to receive bridged shares on source network.
+     * @return fee required to bridge shares.
      */
     function previewFee(uint256 amount, address to) public view returns (uint256 fee) {
         Client.EVM2AnyMessage memory message = _buildMessage(amount, to);
@@ -124,6 +131,7 @@ contract DestinationMinter is ERC20, CCIPReceiver {
 
     /**
      * @notice Implement internal _ccipRecevie function logic.
+     * @param any2EvmMessage CCIP encoded message specifying details to use to 'mint' `share` tokens to a specified address `to` on destination network.
      */
     function _ccipReceive(
         Client.Any2EVMMessage memory any2EvmMessage
@@ -141,6 +149,9 @@ contract DestinationMinter is ERC20, CCIPReceiver {
 
     /**
      * @notice Build the CCIP message to send to source locker.
+     * @param amount number of `share` token to bridge.
+     * @param to Specified address to receive unlocked bridged shares on source network.
+     * @return message the CCIP message to send to source locker.
      */
     function _buildMessage(uint256 amount, address to) internal view returns (Client.EVM2AnyMessage memory message) {
         message = Client.EVM2AnyMessage({

--- a/src/modules/multi-chain-share/DestinationMinter.sol
+++ b/src/modules/multi-chain-share/DestinationMinter.sol
@@ -86,6 +86,7 @@ contract DestinationMinter is ERC20, CCIPReceiver {
 
     /**
      * @notice Bridge shares back to source chain.
+     * @dev Caller should approve LINK to be spent by this contract.
      * @param amount Number of shares to burn on destination network and unlock/transfer on source network.
      * @param to Specified address to burn destination network `share` tokens, and receive unlocked `share` tokens on source network.
      * @param maxLinkToPay Specified max amount of LINK fees to pay as per this contract.

--- a/src/modules/multi-chain-share/DestinationMinterFactory.sol
+++ b/src/modules/multi-chain-share/DestinationMinterFactory.sol
@@ -158,7 +158,7 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
     //============================== CCIP RECEIVER ===============================
 
     /**
-     * @notice Implement internal _ccipRecevie function logic.
+     * @notice Implement internal _ccipReceive function logic.
      * @param any2EvmMessage CCIP encoded message specifying details to use to create paired DestinationMinter.
      */
     function _ccipReceive(

--- a/src/modules/multi-chain-share/DestinationMinterFactory.sol
+++ b/src/modules/multi-chain-share/DestinationMinterFactory.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import { Owned } from "@solmate/auth/Owned.sol";
+import { Math } from "src/utils/Math.sol";
+import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { CCIPReceiver } from "@ccip/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol";
+import { Client } from "@ccip/contracts/src/v0.8/ccip/libraries/Client.sol";
+import { DestinationMinter } from "./DestinationMinter.sol";
+import { IRouterClient } from "@ccip/contracts/src/v0.8/ccip/interfaces/IRouterClient.sol";
+import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+
+/**
+ * @title DestinationMinterFactory
+ * @notice Works with SourceLockerFactory to create new bridgeable ERC4626 Shares.
+ * @author crispymangoes
+ */
+contract DestinationMinterFactory is Owned, CCIPReceiver {
+    using SafeTransferLib for ERC20;
+
+    // ========================================= GLOBAL STATE =========================================
+    /**
+     * @notice Mapping to keep track of failed CCIP messages, and retry them at a later time.
+     */
+    mapping(bytes32 => bool) public canRetryFailedMessage;
+
+    /**
+     * @notice The message gas limit to use for CCIP messages.
+     */
+    uint256 public messageGasLimit;
+
+    /**
+     * @notice The message gas limit DestinationMinter's will use to send messages to their SourceLockers.
+     */
+    uint256 public minterMessageGasLimit;
+
+    //============================== ERRORS ===============================
+
+    error DestinationMinterFactory___SourceChainNotAllowlisted(uint64 sourceChainSelector);
+    error DestinationMinterFactory___SenderNotAllowlisted(address sender);
+    error DestinationMinterFactory___NotEnoughLink();
+    error DestinationMinterFactory___CanNotRetryCallback();
+
+    //============================== EVENTS ===============================
+
+    event CallBackMessageId(bytes32 id);
+    event FailedToSendCallBack(address source, address minter);
+
+    //============================== MODIFIERS ===============================
+
+    modifier onlyAllowlisted(uint64 _sourceChainSelector, address _sender) {
+        if (_sourceChainSelector != sourceChainSelector)
+            revert DestinationMinterFactory___SourceChainNotAllowlisted(_sourceChainSelector);
+        if (_sender != sourceLockerFactory) revert DestinationMinterFactory___SenderNotAllowlisted(_sender);
+        _;
+    }
+
+    //============================== IMMUTABLES ===============================
+
+    /**
+     * @notice The address of the SourceLockerFactory.
+     */
+    address public immutable sourceLockerFactory;
+
+    /**
+     * @notice The CCIP source chain selector.
+     */
+    uint64 public immutable sourceChainSelector;
+
+    /**
+     * @notice The CCIP destination chain selector.
+     */
+    uint64 public immutable destinationChainSelector;
+
+    /**
+     * @notice This networks LINK contract.
+     */
+    ERC20 public immutable LINK;
+
+    constructor(
+        address _owner,
+        address _router,
+        address _sourceLockerFactory,
+        uint64 _sourceChainSelector,
+        uint64 _destinationChainSelector,
+        address _link,
+        uint256 _messageGasLimit,
+        uint256 _minterMessageGasLimit
+    ) Owned(_owner) CCIPReceiver(_router) {
+        sourceLockerFactory = _sourceLockerFactory;
+        sourceChainSelector = _sourceChainSelector;
+        destinationChainSelector = _destinationChainSelector;
+        LINK = ERC20(_link);
+        messageGasLimit = _messageGasLimit;
+        minterMessageGasLimit = _minterMessageGasLimit;
+    }
+
+    //============================== ADMIN FUNCTIONS ===============================
+
+    /**
+     * @notice Allows admin to withdraw ERC20s from this factory contract.
+     */
+    function adminWithdraw(ERC20 token, uint256 amount, address to) external onlyOwner {
+        token.safeTransfer(to, amount);
+    }
+
+    /**
+     * @notice Allows admin to set this factories callback CCIP message gas limit.
+     * @dev Note Owner can set a gas limit that is too low, and cause the callback messages to run out of gas.
+     *           If this happens the owner should raise gas limit, and call `deploy` on SourceLockerFactory again.
+     */
+    function setMessageGasLimit(uint256 limit) external onlyOwner {
+        messageGasLimit = limit;
+    }
+
+    /**
+     * @notice Allows admin to set newly deployed DestinationMinter message gas limits
+     * @dev Note This only effects newly deployed DestinationMinters.
+     */
+    function setMinterMessageGasLimit(uint256 limit) external onlyOwner {
+        minterMessageGasLimit = limit;
+    }
+
+    //============================== RETRY FUNCTIONS ===============================
+
+    /**
+     * @notice Allows anyone to retry sending callback to source locker factory.
+     */
+    function retryCallback(address targetSource, address targetMinter) external {
+        bytes32 messageDataHash = keccak256(abi.encode(targetSource, targetMinter));
+        if (!canRetryFailedMessage[messageDataHash]) revert DestinationMinterFactory___CanNotRetryCallback();
+
+        canRetryFailedMessage[messageDataHash] = false;
+
+        Client.EVM2AnyMessage memory message = _buildMessage(targetSource, targetMinter);
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        uint256 fees = router.getFee(sourceChainSelector, message);
+
+        if (fees > LINK.balanceOf(address(this))) revert DestinationMinterFactory___NotEnoughLink();
+
+        LINK.safeApprove(address(router), fees);
+
+        bytes32 messageId = router.ccipSend(sourceChainSelector, message);
+        emit CallBackMessageId(messageId);
+    }
+
+    //============================== CCIP RECEIVER ===============================
+
+    /**
+     * @notice Implement internal _ccipRecevie function logic.
+     */
+    function _ccipReceive(
+        Client.Any2EVMMessage memory any2EvmMessage
+    )
+        internal
+        override
+        onlyAllowlisted(any2EvmMessage.sourceChainSelector, abi.decode(any2EvmMessage.sender, (address)))
+    {
+        (address targetSource, string memory name, string memory symbol, uint8 decimals) = abi.decode(
+            any2EvmMessage.data,
+            (address, string, string, uint8)
+        );
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        address targetMinter = address(
+            new DestinationMinter(
+                address(router),
+                targetSource,
+                name,
+                symbol,
+                decimals,
+                sourceChainSelector,
+                destinationChainSelector,
+                address(LINK),
+                minterMessageGasLimit
+            )
+        );
+        // CCIP sends message back to SourceLockerFactory with new DestinationMinter address, and corresponding source locker
+        Client.EVM2AnyMessage memory message = _buildMessage(targetSource, targetMinter);
+
+        uint256 fees = router.getFee(sourceChainSelector, message);
+
+        if (fees > LINK.balanceOf(address(this))) {
+            // Fees is larger than the LINK in contract, so update `canRetryFailedMessage`, and return.
+            bytes32 messageDataHash = keccak256(abi.encode(targetSource, targetMinter));
+            canRetryFailedMessage[messageDataHash] = true;
+            emit FailedToSendCallBack(targetSource, targetMinter);
+            return;
+        }
+
+        LINK.safeApprove(address(router), fees);
+
+        bytes32 messageId = router.ccipSend(sourceChainSelector, message);
+        emit CallBackMessageId(messageId);
+    }
+
+    //============================== INTERNAL HELPER FUNCTIONS ===============================
+
+    /**
+     * @notice Build the CCIP message to send to source locker factory.
+     */
+    function _buildMessage(
+        address targetSource,
+        address targetMinter
+    ) internal view returns (Client.EVM2AnyMessage memory message) {
+        message = Client.EVM2AnyMessage({
+            receiver: abi.encode(sourceLockerFactory),
+            data: abi.encode(targetSource, targetMinter),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: Client._argsToBytes(
+                // Additional arguments, setting gas limit and non-strict sequencing mode
+                Client.EVMExtraArgsV1({ gasLimit: messageGasLimit /*, strict: false*/ })
+            ),
+            feeToken: address(LINK)
+        });
+    }
+}

--- a/src/modules/multi-chain-share/DestinationMinterFactory.sol
+++ b/src/modules/multi-chain-share/DestinationMinterFactory.sol
@@ -13,7 +13,8 @@ import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
 
 /**
  * @title DestinationMinterFactory
- * @notice Works with SourceLockerFactory to create new bridgeable ERC4626 Shares.
+ * @notice Works with SourceLockerFactory to create pairs of Source Lockers & Destination Minters for new bridgeable ERC4626 Shares  
+ * @dev Source Lockers lock up shares to bridge a mint request to paired Destination Minters, where the representation of the Source Network Shares is minted on Destination Network. 
  * @author crispymangoes
  */
 contract DestinationMinterFactory is Owned, CCIPReceiver {
@@ -100,6 +101,9 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
 
     /**
      * @notice Allows admin to withdraw ERC20s from this factory contract.
+     * @param token specified ERC20 to withdraw.
+     * @param amount number of ERC20 token to withdraw.
+     * @param to receiver of the respective ERC20 tokens.
      */
     function adminWithdraw(ERC20 token, uint256 amount, address to) external onlyOwner {
         token.safeTransfer(to, amount);
@@ -109,6 +113,7 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
      * @notice Allows admin to set this factories callback CCIP message gas limit.
      * @dev Note Owner can set a gas limit that is too low, and cause the callback messages to run out of gas.
      *           If this happens the owner should raise gas limit, and call `deploy` on SourceLockerFactory again.
+     * @param limit Specified CCIP message gas limit.
      */
     function setMessageGasLimit(uint256 limit) external onlyOwner {
         messageGasLimit = limit;
@@ -117,6 +122,7 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
     /**
      * @notice Allows admin to set newly deployed DestinationMinter message gas limits
      * @dev Note This only effects newly deployed DestinationMinters.
+     * @param limit Specified CCIP message gas limit.
      */
     function setMinterMessageGasLimit(uint256 limit) external onlyOwner {
         minterMessageGasLimit = limit;
@@ -126,6 +132,8 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
 
     /**
      * @notice Allows anyone to retry sending callback to source locker factory.
+     * @param targetSource The Source Locker (on source network).
+     * @param targetMinter The Destination Minter (on this Destination Network).
      */
     function retryCallback(address targetSource, address targetMinter) external {
         bytes32 messageDataHash = keccak256(abi.encode(targetSource, targetMinter));
@@ -151,6 +159,7 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
 
     /**
      * @notice Implement internal _ccipRecevie function logic.
+     * @param any2EvmMessage CCIP encoded message specifying details to use to create paired DestinationMinter.
      */
     function _ccipReceive(
         Client.Any2EVMMessage memory any2EvmMessage
@@ -202,6 +211,9 @@ contract DestinationMinterFactory is Owned, CCIPReceiver {
 
     /**
      * @notice Build the CCIP message to send to source locker factory.
+     * @param targetSource The Source Locker (on source network).
+     * @param targetMinter The Destination Minter (on this Destination Network).
+     * @return message the CCIP message to send to source locker factory.
      */
     function _buildMessage(
         address targetSource,

--- a/src/modules/multi-chain-share/SourceLocker.sol
+++ b/src/modules/multi-chain-share/SourceLocker.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { CCIPReceiver } from "@ccip/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol";
+import { Client } from "@ccip/contracts/src/v0.8/ccip/libraries/Client.sol";
+import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+import { IRouterClient } from "@ccip/contracts/src/v0.8/ccip/interfaces/IRouterClient.sol";
+
+/**
+ * @title SourceLocker
+ * @notice Receives CCIP messages from DestinationMinter, to release ERC4626 shares that
+ *         were previously bridged to destination chain.
+ * @author crispymangoes
+ */
+contract SourceLocker is CCIPReceiver {
+    using SafeTransferLib for ERC20;
+
+    // ========================================= GLOBAL STATE =========================================
+
+    /**
+     * @notice The Destination Minter on destination chain.
+     */
+    address public targetDestination;
+
+    //============================== ERRORS ===============================
+
+    error SourceLocker___SourceChainNotAllowlisted(uint64 sourceChainSelector);
+    error SourceLocker___SenderNotAllowlisted(address sender);
+    error SourceLocker___OnlyFactory();
+    error SourceLocker___TargetDestinationAlreadySet();
+    error SourceLocker___InvalidTo();
+    error SourceLocker___FeeTooHigh();
+    error SourceLocker___TargetDestinationNotSet();
+
+    //============================== EVENTS ===============================
+
+    event BridgeToDestination(uint256 amount, address to);
+    event BridgeFromDestination(uint256 amount, address to);
+
+    //============================== MODIFIERS ===============================
+
+    modifier onlyAllowlisted(uint64 _sourceChainSelector, address _sender) {
+        if (_sourceChainSelector != destinationChainSelector)
+            revert SourceLocker___SourceChainNotAllowlisted(_sourceChainSelector);
+        if (_sender != targetDestination) revert SourceLocker___SenderNotAllowlisted(_sender);
+        _;
+    }
+
+    //============================== IMMUTABLES ===============================
+
+    /**
+     * @notice ERC20 share token to bridge.
+     */
+    ERC20 public immutable shareToken;
+
+    /**
+     * @notice The address of the SourceLockerFactory.
+     */
+    address public immutable factory;
+
+    /**
+     * @notice The CCIP source chain selector.
+     */
+    uint64 public immutable sourceChainSelector;
+
+    /**
+     * @notice The CCIP destination chain selector.
+     */
+    uint64 public immutable destinationChainSelector;
+
+    /**
+     * @notice This networks LINK contract.
+     */
+    ERC20 public immutable LINK;
+
+    /**
+     * @notice The message gas limit to use for CCIP messages.
+     */
+    uint256 public immutable messageGasLimit;
+
+    constructor(
+        address _router,
+        address _shareToken,
+        address _factory,
+        uint64 _sourceChainSelector,
+        uint64 _destinationChainSelector,
+        address _link,
+        uint256 _messageGasLimit
+    ) CCIPReceiver(_router) {
+        shareToken = ERC20(_shareToken);
+        factory = _factory;
+        sourceChainSelector = _sourceChainSelector;
+        destinationChainSelector = _destinationChainSelector;
+        LINK = ERC20(_link);
+        messageGasLimit = _messageGasLimit;
+    }
+
+    //============================== ONLY FACTORY ===============================
+
+    /**
+     * @notice Allows factory to set target destination.
+     */
+    function setTargetDestination(address _targetDestination) external {
+        if (msg.sender != factory) revert SourceLocker___OnlyFactory();
+        if (targetDestination != address(0)) revert SourceLocker___TargetDestinationAlreadySet();
+
+        targetDestination = _targetDestination;
+    }
+
+    //============================== BRIDGE ===============================
+
+    /**
+     * @notice Bridge shares to destination chain.
+     * @notice Reverts if target destination is not yet set.
+     */
+    function bridgeToDestination(
+        uint256 amount,
+        address to,
+        uint256 maxLinkToPay
+    ) external returns (bytes32 messageId) {
+        if (to == address(0)) revert SourceLocker___InvalidTo();
+        shareToken.safeTransferFrom(msg.sender, address(this), amount);
+
+        Client.EVM2AnyMessage memory message = _buildMessage(amount, to);
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        uint256 fees = router.getFee(destinationChainSelector, message);
+
+        if (fees > maxLinkToPay) revert SourceLocker___FeeTooHigh();
+
+        LINK.safeTransferFrom(msg.sender, address(this), fees);
+
+        LINK.safeApprove(address(router), fees);
+
+        messageId = router.ccipSend(destinationChainSelector, message);
+        emit BridgeToDestination(amount, to);
+    }
+
+    //============================== VIEW FUNCTIONS ===============================
+
+    /**
+     * @notice Preview fee required to bridge shares to destination.
+     */
+    function previewFee(uint256 amount, address to) public view returns (uint256 fee) {
+        Client.EVM2AnyMessage memory message = _buildMessage(amount, to);
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        fee = router.getFee(destinationChainSelector, message);
+    }
+
+    //============================== CCIP RECEIVER ===============================
+
+    /**
+     * @notice Implement internal _ccipRecevie function logic.
+     */
+    function _ccipReceive(
+        Client.Any2EVMMessage memory any2EvmMessage
+    )
+        internal
+        override
+        onlyAllowlisted(any2EvmMessage.sourceChainSelector, abi.decode(any2EvmMessage.sender, (address)))
+    {
+        (uint256 amount, address to) = abi.decode(any2EvmMessage.data, (uint256, address));
+        shareToken.safeTransfer(to, amount);
+        emit BridgeFromDestination(amount, to);
+    }
+
+    //============================== INTERNAL HELPER ===============================
+
+    /**
+     * @notice Build the CCIP message to send to destination minter.
+     * @notice Reverts if target destination is not yet set.
+     */
+    function _buildMessage(uint256 amount, address to) internal view returns (Client.EVM2AnyMessage memory message) {
+        address _targetDestination = targetDestination;
+        if (_targetDestination == address(0)) revert SourceLocker___TargetDestinationNotSet();
+        message = Client.EVM2AnyMessage({
+            receiver: abi.encode(_targetDestination),
+            data: abi.encode(amount, to),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: Client._argsToBytes(
+                // Additional arguments, setting gas limit and non-strict sequencing mode
+                Client.EVMExtraArgsV1({ gasLimit: messageGasLimit /*, strict: false*/ })
+            ),
+            feeToken: address(LINK)
+        });
+    }
+}

--- a/src/modules/multi-chain-share/SourceLocker.sol
+++ b/src/modules/multi-chain-share/SourceLocker.sol
@@ -115,7 +115,7 @@ contract SourceLocker is CCIPReceiver {
      * @notice Reverts if target destination is not yet set.
      * @param amount number of `share` token to bridge.
      * @param to Specified address to receive newly minted bridged shares on destination network.
-     * @param maxLinkToPay Specified max amount of LINK fees to pay as per this contract.
+     * @param maxLinkToPay Specified max amount of LINK fees to pay.
      * @return messageId Resultant CCIP messageId.
      */
     function bridgeToDestination(

--- a/src/modules/multi-chain-share/SourceLockerFactory.sol
+++ b/src/modules/multi-chain-share/SourceLockerFactory.sol
@@ -132,6 +132,8 @@ contract SourceLockerFactory is Owned, CCIPReceiver {
 
     /**
      * @notice Allows admin to deploy a new SourceLocker and DestinationMinter, for a given `share`.
+     * @dev Note Owner can set a gas limit that is too low, and cause the message to run out of gas.
+     *           If this happens the owner should raise gas limit, and call `deploy` on SourceLockerFactory again.
      * @param target Specified `share` token for a ERC4626 vault.
      * @return messageId Resultant CCIP messageId.
      * @return newLocker Newly deployed Source Locker for specified `target`

--- a/src/modules/multi-chain-share/SourceLockerFactory.sol
+++ b/src/modules/multi-chain-share/SourceLockerFactory.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import { Owned } from "@solmate/auth/Owned.sol";
+import { SourceLocker } from "./SourceLocker.sol";
+import { ERC4626 } from "@solmate/mixins/ERC4626.sol";
+import { CCIPReceiver } from "@ccip/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol";
+import { Client } from "@ccip/contracts/src/v0.8/ccip/libraries/Client.sol";
+import { IRouterClient } from "@ccip/contracts/src/v0.8/ccip/interfaces/IRouterClient.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+
+/**
+ * @title SourceLockerFactory
+ * @notice Works with DestinationMinterFactory to create new bridgeable ERC4626 Shares.
+ * @author crispymangoes
+ */
+contract SourceLockerFactory is Owned, CCIPReceiver {
+    using SafeTransferLib for ERC20;
+
+    // ========================================= GLOBAL STATE =========================================
+
+    /**
+     * @notice Destination Minter Factory.
+     */
+    address public destinationMinterFactory;
+
+    /**
+     * @notice The message gas limit to use for CCIP messages.
+     */
+    uint256 public messageGasLimit;
+
+    /**
+     * @notice The message gas limit SourceLockers's will use to send messages to their DestinationMinters.
+     */
+    uint256 public lockerMessageGasLimit;
+
+    //============================== ERRORS ===============================
+
+    error SourceLockerFactory___SourceChainNotAllowlisted(uint64 sourceChainSelector);
+    error SourceLockerFactory___SenderNotAllowlisted(address sender);
+    error SourceLockerFactory___NotEnoughLink();
+    error SourceLockerFactory___FactoryAlreadySet();
+
+    //============================== EVENTS ===============================
+
+    event DeploySuccess(address share, address locker, address minter);
+
+    //============================== MODIFIERS ===============================
+
+    modifier onlyAllowlisted(uint64 _sourceChainSelector, address _sender) {
+        if (_sourceChainSelector != destinationChainSelector)
+            revert SourceLockerFactory___SourceChainNotAllowlisted(_sourceChainSelector);
+        if (_sender != destinationMinterFactory) revert SourceLockerFactory___SenderNotAllowlisted(_sender);
+        _;
+    }
+
+    //============================== IMMUTABLES ===============================
+
+    /**
+     * @notice The CCIP source chain selector.
+     */
+    uint64 public immutable sourceChainSelector;
+
+    /**
+     * @notice The CCIP destination chain selector.
+     */
+    uint64 public immutable destinationChainSelector;
+
+    /**
+     * @notice This networks LINK contract.
+     */
+    ERC20 public immutable LINK;
+
+    constructor(
+        address _owner,
+        address _router,
+        uint64 _sourceChainSelector,
+        uint64 _destinationChainSelector,
+        address _link,
+        uint256 _messageGasLimit,
+        uint256 _lockerMessageGasLimit
+    ) Owned(_owner) CCIPReceiver(_router) {
+        sourceChainSelector = _sourceChainSelector;
+        destinationChainSelector = _destinationChainSelector;
+        LINK = ERC20(_link);
+        messageGasLimit = _messageGasLimit;
+        lockerMessageGasLimit = _lockerMessageGasLimit;
+    }
+
+    //============================== ADMIN FUNCTIONS ===============================
+
+    /**
+     * @notice Allows admin to withdraw ERC20s from this factory contract.
+     */
+    function adminWithdraw(ERC20 token, uint256 amount, address to) external onlyOwner {
+        token.safeTransfer(to, amount);
+    }
+
+    /**
+     * @notice Allows admin to link DestinationMinterFactory to this factory.
+     */
+    function setDestinationMinterFactory(address _destinationMinterFactory) external onlyOwner {
+        if (destinationMinterFactory != address(0)) revert SourceLockerFactory___FactoryAlreadySet();
+        destinationMinterFactory = _destinationMinterFactory;
+    }
+
+    /**
+     * @notice Allows admin to set this factories CCIP message gas limit.
+     * @dev Note Owner can set a gas limit that is too low, and cause the message to run out of gas.
+     *           If this happens the owner should raise gas limit, and call `deploy` on SourceLockerFactory again.
+     */
+    function setMessageGasLimit(uint256 limit) external onlyOwner {
+        messageGasLimit = limit;
+    }
+
+    /**
+     * @notice Allows admin to set newly deployed SourceLocker message gas limits
+     * @dev Note This only effects newly deployed SourceLockers.
+     */
+    function setLockerMessageGasLimit(uint256 limit) external onlyOwner {
+        lockerMessageGasLimit = limit;
+    }
+
+    /**
+     * @notice Allows admin to deploy a new SourceLocker and DestinationMinter, for a given `share`.
+     */
+    function deploy(ERC20 target) external onlyOwner returns (bytes32 messageId, address newLocker) {
+        // Deploy a new Source Target
+        SourceLocker locker = new SourceLocker(
+            this.getRouter(),
+            address(target),
+            address(this),
+            sourceChainSelector,
+            destinationChainSelector,
+            address(LINK),
+            lockerMessageGasLimit
+        );
+        // CCIP Send new Source Target address, target.name(), target.symbol(), target.decimals() to DestinationMinterFactory.
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationMinterFactory),
+            data: abi.encode(address(locker), target.name(), target.symbol(), target.decimals()),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            extraArgs: Client._argsToBytes(
+                // Additional arguments, setting gas limit and non-strict sequencing mode
+                Client.EVMExtraArgsV1({ gasLimit: messageGasLimit /*, strict: false*/ })
+            ),
+            feeToken: address(LINK)
+        });
+
+        IRouterClient router = IRouterClient(this.getRouter());
+
+        uint256 fees = router.getFee(destinationChainSelector, message);
+
+        if (fees > LINK.balanceOf(address(this))) revert SourceLockerFactory___NotEnoughLink();
+
+        LINK.safeApprove(address(router), fees);
+
+        messageId = router.ccipSend(destinationChainSelector, message);
+        newLocker = address(locker);
+    }
+
+    //============================== CCIP RECEIVER ===============================
+
+    /**
+     * @notice Implement internal _ccipRecevie function logic.
+     */
+    function _ccipReceive(
+        Client.Any2EVMMessage memory any2EvmMessage
+    )
+        internal
+        override
+        onlyAllowlisted(any2EvmMessage.sourceChainSelector, abi.decode(any2EvmMessage.sender, (address)))
+    {
+        (address targetLocker, address targetDestination) = abi.decode(any2EvmMessage.data, (address, address));
+
+        SourceLocker locker = SourceLocker(targetLocker);
+
+        locker.setTargetDestination(targetDestination);
+
+        emit DeploySuccess(address(locker.shareToken()), targetLocker, targetDestination);
+    }
+}

--- a/src/modules/multi-chain-share/SourceLockerFactory.sol
+++ b/src/modules/multi-chain-share/SourceLockerFactory.sol
@@ -13,8 +13,8 @@ import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
 /**
  * @title SourceLockerFactory
  * @notice Works with DestinationMinterFactory to create pairs of Source Lockers & Destination Minters for new bridgeable ERC4626 Shares
- * @dev SourceLockerFactory `deploy()` function is used to enact the creation of SourceLocker and DestinationMinter pairs.  
- * @dev Source Lockers lock up shares to bridge a mint request to paired Destination Minters, where the representation of the Source Network Shares is minted on Destination Network. 
+ * @dev SourceLockerFactory `deploy()` function is used to enact the creation of SourceLocker and DestinationMinter pairs.
+ * @dev Source Lockers lock up shares to bridge a mint request to paired Destination Minters, where the representation of the Source Network Shares is minted on Destination Network.
  * @author crispymangoes
  */
 contract SourceLockerFactory is Owned, CCIPReceiver {
@@ -70,7 +70,7 @@ contract SourceLockerFactory is Owned, CCIPReceiver {
     uint64 public immutable destinationChainSelector;
 
     /**
-     * @notice This networks LINK contract.
+     * @notice This network's LINK contract.
      */
     ERC20 public immutable LINK;
 

--- a/test/MultiChainShare.t.sol
+++ b/test/MultiChainShare.t.sol
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+// Import Everything from Starter file.
+import "test/resources/MainnetStarter.t.sol";
+
+import { AdaptorHelperFunctions } from "test/resources/AdaptorHelperFunctions.sol";
+import { SourceLockerFactory } from "src/modules/multi-chain-share/SourceLockerFactory.sol";
+import { DestinationMinterFactory } from "src/modules/multi-chain-share/DestinationMinterFactory.sol";
+import { SourceLocker } from "src/modules/multi-chain-share/SourceLocker.sol";
+import { DestinationMinter } from "src/modules/multi-chain-share/DestinationMinter.sol";
+import { CCIPReceiver } from "@ccip/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol";
+
+import { MockCCIPRouter } from "src/mocks/MockCCIPRouter.sol";
+import { ERC4626 } from "@solmate/mixins/ERC4626.sol";
+import { Client } from "@ccip/contracts/src/v0.8/ccip/libraries/Client.sol";
+
+contract MultiChainShareTest is MainnetStarterTest, AdaptorHelperFunctions {
+    SourceLockerFactory public sourceLockerFactory;
+    DestinationMinterFactory public destinationMinterFactory;
+
+    MockCCIPRouter public router;
+
+    // Use Real Yield USD.
+    ERC4626 public cellar = ERC4626(0x97e6E0a40a3D02F12d1cEC30ebfbAE04e37C119E);
+
+    function setUp() external {
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 16869780;
+        _startFork(rpcKey, blockNumber);
+
+        // Run Starter setUp code.
+        _setUp();
+        router = new MockCCIPRouter(address(LINK));
+
+        sourceLockerFactory = new SourceLockerFactory(
+            address(this),
+            address(router),
+            router.SOURCE_SELECTOR(),
+            router.DESTINATION_SELECTOR(),
+            address(LINK),
+            2_000_000,
+            200_000
+        );
+
+        destinationMinterFactory = new DestinationMinterFactory(
+            address(this),
+            address(router),
+            address(sourceLockerFactory),
+            router.SOURCE_SELECTOR(),
+            router.DESTINATION_SELECTOR(),
+            address(LINK),
+            200_000,
+            200_000
+        );
+
+        sourceLockerFactory.setDestinationMinterFactory(address(destinationMinterFactory));
+
+        deal(address(LINK), address(sourceLockerFactory), 1_000e18);
+        deal(address(LINK), address(destinationMinterFactory), 1_000e18);
+        deal(address(LINK), address(this), 1_000e18);
+    }
+
+    function testAdminWithdraw() external {
+        // Both factories have an admin withdraw function to withdraw LINK from them.
+        uint256 expectedLinkBalance = LINK.balanceOf(address(this));
+        uint256 linkBalance = LINK.balanceOf(address(sourceLockerFactory));
+        expectedLinkBalance += linkBalance;
+        sourceLockerFactory.adminWithdraw(LINK, linkBalance, address(this));
+
+        linkBalance = LINK.balanceOf(address(destinationMinterFactory));
+        expectedLinkBalance += linkBalance;
+        destinationMinterFactory.adminWithdraw(LINK, linkBalance, address(this));
+
+        assertEq(LINK.balanceOf(address(this)), expectedLinkBalance, "Balance does not equal expected.");
+
+        // Try calling it from a non owner address.
+        address nonOwner = vm.addr(1);
+        vm.startPrank(nonOwner);
+        vm.expectRevert(bytes("UNAUTHORIZED"));
+        sourceLockerFactory.adminWithdraw(LINK, linkBalance, address(this));
+
+        vm.expectRevert(bytes("UNAUTHORIZED"));
+        destinationMinterFactory.adminWithdraw(LINK, linkBalance, address(this));
+        vm.stopPrank();
+    }
+
+    function testHappyPath(uint256 amountToDesintation, uint256 amountToSource) external {
+        amountToDesintation = bound(amountToDesintation, 1e6, type(uint96).max);
+        amountToSource = bound(amountToSource, 0.999e6, amountToDesintation);
+
+        (SourceLocker locker, DestinationMinter minter) = _runDeploy();
+
+        // Try bridging shares.
+        deal(address(cellar), address(this), amountToDesintation);
+        cellar.approve(address(locker), amountToDesintation);
+        uint256 fee = locker.previewFee(amountToDesintation, address(this));
+        LINK.approve(address(locker), fee);
+        locker.bridgeToDestination(amountToDesintation, address(this), fee);
+
+        Client.Any2EVMMessage memory message = router.getLastMessage();
+
+        vm.prank(address(router));
+        minter.ccipReceive(message);
+
+        assertEq(amountToDesintation, minter.balanceOf(address(this)), "Should have minted shares.");
+        assertEq(0, cellar.balanceOf(address(this)), "Should have spent Cellar shares.");
+
+        // Try bridging the shares back.
+        fee = minter.previewFee(amountToSource, address(this));
+        LINK.approve(address(minter), 1e18);
+        minter.bridgeToSource(amountToSource, address(this), 1e18);
+
+        message = router.getLastMessage();
+
+        vm.prank(address(router));
+        locker.ccipReceive(message);
+
+        assertEq(amountToDesintation - amountToSource, minter.balanceOf(address(this)), "Should have burned shares.");
+        assertEq(
+            amountToSource,
+            cellar.balanceOf(address(this)),
+            "Should have sent Cellar shares back to this address."
+        );
+    }
+
+    //---------------------------------------- REVERT TESTS ----------------------------------------
+
+    function testCcipReceiveChecks() external {
+        // Deploy a source and minter.
+        (SourceLocker locker, DestinationMinter minter) = _runDeploy();
+        // Try calling ccipReceive function on all contracts using attacker contract.
+        address attacker = vm.addr(0xBAD);
+        uint64 badSourceChain = 1;
+
+        Client.Any2EVMMessage memory badMessage;
+        badMessage.sender = abi.encode(attacker);
+        badMessage.sourceChainSelector = badSourceChain;
+
+        vm.startPrank(attacker);
+        // Revert if caller is not CCIP Router.
+        vm.expectRevert(bytes(abi.encodeWithSelector(CCIPReceiver.InvalidRouter.selector, attacker)));
+        sourceLockerFactory.ccipReceive(badMessage);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(CCIPReceiver.InvalidRouter.selector, attacker)));
+        destinationMinterFactory.ccipReceive(badMessage);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(CCIPReceiver.InvalidRouter.selector, attacker)));
+        locker.ccipReceive(badMessage);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(CCIPReceiver.InvalidRouter.selector, attacker)));
+        minter.ccipReceive(badMessage);
+        vm.stopPrank();
+
+        // Revert if source chain selector is wrong.
+        vm.startPrank(address(router));
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    SourceLockerFactory.SourceLockerFactory___SourceChainNotAllowlisted.selector,
+                    badSourceChain
+                )
+            )
+        );
+        sourceLockerFactory.ccipReceive(badMessage);
+
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    DestinationMinterFactory.DestinationMinterFactory___SourceChainNotAllowlisted.selector,
+                    badSourceChain
+                )
+            )
+        );
+        destinationMinterFactory.ccipReceive(badMessage);
+
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(SourceLocker.SourceLocker___SourceChainNotAllowlisted.selector, badSourceChain)
+            )
+        );
+        locker.ccipReceive(badMessage);
+
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    DestinationMinter.DestinationMinter___SourceChainNotAllowlisted.selector,
+                    badSourceChain
+                )
+            )
+        );
+        minter.ccipReceive(badMessage);
+
+        // Revert if message sender is wrong.
+        badMessage.sourceChainSelector = locker.destinationChainSelector();
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    SourceLockerFactory.SourceLockerFactory___SenderNotAllowlisted.selector,
+                    attacker
+                )
+            )
+        );
+        sourceLockerFactory.ccipReceive(badMessage);
+
+        vm.expectRevert(
+            bytes(abi.encodeWithSelector(SourceLocker.SourceLocker___SenderNotAllowlisted.selector, attacker))
+        );
+        locker.ccipReceive(badMessage);
+
+        badMessage.sourceChainSelector = locker.sourceChainSelector();
+
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(
+                    DestinationMinterFactory.DestinationMinterFactory___SenderNotAllowlisted.selector,
+                    attacker
+                )
+            )
+        );
+        destinationMinterFactory.ccipReceive(badMessage);
+
+        vm.expectRevert(
+            bytes(abi.encodeWithSelector(DestinationMinter.DestinationMinter___SenderNotAllowlisted.selector, attacker))
+        );
+        minter.ccipReceive(badMessage);
+
+        vm.stopPrank();
+    }
+
+    function testSourceLockerFactoryReverts() external {
+        // Trying to set factory again reverts.
+        vm.expectRevert(
+            bytes(abi.encodeWithSelector(SourceLockerFactory.SourceLockerFactory___FactoryAlreadySet.selector))
+        );
+        sourceLockerFactory.setDestinationMinterFactory(address(0));
+
+        // Calling deploy when sourceLockerFactory does not have enough Link.
+        deal(address(LINK), address(sourceLockerFactory), 0);
+        vm.expectRevert(
+            bytes(abi.encodeWithSelector(SourceLockerFactory.SourceLockerFactory___NotEnoughLink.selector))
+        );
+        sourceLockerFactory.deploy(cellar);
+    }
+
+    function testDestinationMinterFactoryRetryCallback() external {
+        SourceLocker locker;
+        DestinationMinter minter;
+
+        (, address lockerAddress) = sourceLockerFactory.deploy(cellar);
+
+        locker = SourceLocker(lockerAddress);
+
+        // Zero out destination minter facotry Link balance so CCIP call reverts.
+        deal(address(LINK), address(destinationMinterFactory), 0);
+
+        // Simulate CCIP Message to destination factory.
+        Client.Any2EVMMessage memory message = router.getLastMessage();
+        vm.prank(address(router));
+        destinationMinterFactory.ccipReceive(message);
+
+        address expectedMinterAddress = 0x5B0091f49210e7B2A57B03dfE1AB9D08289d9294;
+
+        bytes32 messageDataHash = keccak256(abi.encode(address(locker), expectedMinterAddress));
+        assertTrue(
+            destinationMinterFactory.canRetryFailedMessage(messageDataHash),
+            "Should have updated mapping to true."
+        );
+
+        // Try retrying callback without sending link to factory.
+        vm.expectRevert(
+            bytes(abi.encodeWithSelector(DestinationMinterFactory.DestinationMinterFactory___NotEnoughLink.selector))
+        );
+        destinationMinterFactory.retryCallback(address(locker), expectedMinterAddress);
+
+        // Callback failed, send destination minter link, and retry.
+        deal(address(LINK), address(destinationMinterFactory), 1e18);
+
+        destinationMinterFactory.retryCallback(address(locker), expectedMinterAddress);
+
+        // Calling retryCallback again should revert.
+        vm.expectRevert(
+            bytes(
+                abi.encodeWithSelector(DestinationMinterFactory.DestinationMinterFactory___CanNotRetryCallback.selector)
+            )
+        );
+        destinationMinterFactory.retryCallback(address(locker), expectedMinterAddress);
+
+        assertTrue(
+            !destinationMinterFactory.canRetryFailedMessage(messageDataHash),
+            "Should have updated mapping to false."
+        );
+
+        // Calll can continue as normal.
+        // Simulate CCIP message to source factory.
+        message = router.getLastMessage();
+        vm.prank(address(router));
+        sourceLockerFactory.ccipReceive(message);
+
+        minter = DestinationMinter(locker.targetDestination());
+    }
+
+    function testSourceLockerReverts() external {
+        (SourceLocker locker, ) = _runDeploy();
+
+        // Only callable by source locker factory.
+        vm.expectRevert(bytes(abi.encodeWithSelector(SourceLocker.SourceLocker___OnlyFactory.selector)));
+        locker.setTargetDestination(address(this));
+
+        // Can only be set once.
+        vm.startPrank(address(sourceLockerFactory));
+        vm.expectRevert(
+            bytes(abi.encodeWithSelector(SourceLocker.SourceLocker___TargetDestinationAlreadySet.selector))
+        );
+        locker.setTargetDestination(address(this));
+        vm.stopPrank();
+
+        uint256 amountToDesintation = 1e18;
+        deal(address(cellar), address(this), amountToDesintation);
+        cellar.approve(address(locker), amountToDesintation);
+        uint256 fee = locker.previewFee(amountToDesintation, address(this));
+        LINK.approve(address(locker), fee);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(SourceLocker.SourceLocker___InvalidTo.selector)));
+        locker.bridgeToDestination(amountToDesintation, address(0), fee);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(SourceLocker.SourceLocker___FeeTooHigh.selector)));
+        locker.bridgeToDestination(amountToDesintation, address(this), 0);
+
+        (, address lockerAddress) = sourceLockerFactory.deploy(cellar);
+
+        locker = SourceLocker(lockerAddress);
+
+        cellar.approve(address(lockerAddress), amountToDesintation);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(SourceLocker.SourceLocker___TargetDestinationNotSet.selector)));
+        locker.bridgeToDestination(amountToDesintation, address(this), fee);
+    }
+
+    function testDestinationMinterReverts() external {
+        (, DestinationMinter minter) = _runDeploy();
+
+        uint256 amountToSource = 10e18;
+        deal(address(minter), address(this), 10e18);
+        uint256 fee = minter.previewFee(amountToSource, address(this));
+        LINK.approve(address(minter), 1e18);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(DestinationMinter.DestinationMinter___InvalidTo.selector)));
+        minter.bridgeToSource(amountToSource, address(0), fee);
+
+        vm.expectRevert(bytes(abi.encodeWithSelector(DestinationMinter.DestinationMinter___FeeTooHigh.selector)));
+        minter.bridgeToSource(amountToSource, address(this), 0);
+
+        // Try bridging more than we have.
+        vm.expectRevert(stdError.arithmeticError);
+        minter.bridgeToSource(amountToSource + 1, address(this), fee);
+    }
+
+    function _runDeploy() internal returns (SourceLocker locker, DestinationMinter minter) {
+        (, address lockerAddress) = sourceLockerFactory.deploy(cellar);
+
+        locker = SourceLocker(lockerAddress);
+
+        // Simulate CCIP Message to destinateion factory.
+        Client.Any2EVMMessage memory message = router.getLastMessage();
+        vm.prank(address(router));
+        destinationMinterFactory.ccipReceive(message);
+
+        // Simulate CCIP message to source factory.
+        message = router.getLastMessage();
+        vm.prank(address(router));
+        sourceLockerFactory.ccipReceive(message);
+
+        minter = DestinationMinter(locker.targetDestination());
+    }
+}


### PR DESCRIPTION
## PR Scope Details

### Core Contracts
1. `DestinationMinter.sol` (DM)
2. `DestinationMinterFactory.sol` (DMF)
3. `SourceLocker.sol` (SL)
4. `SourceLockerFactory.sol` (SLF)

### Sequence of Main Operations for Contracts
1. Factory Contract Deployments:
   - SLF on source network && DMF on destination network.
2. Setup:
   - `setDestinationMinterFactory()` such that they are properly connected.
3. Create new pairs of SL & DM for a specified ERC20 `shareToken` via call: `SourceLockerFactory.deploy()`
   - High-Level: sends a series of msgs via CCIP to DMF and back (callback) to deploy a new SL && DM pair.
      - 1st msg (SLF -> DMF): deploys new DM w/ specs from msg from SF.
      - 2nd msg (DMF -> SLF): `callback` where `SourceLocker.setTargetDestination()` is finally called that finishes the setup of the DM & SL pair for said ERC20 `shareToken` param specified in initial `deploy()` call
4. SL locks up shares to bridge a mint request to DM, where the representation of the Source Network Shares is minted on Destination Network.
   _- Likely setup to start:_
      - A-Tier Cross-Chain-Locker-Minter (CCLM) Pair:
         - Arbitrum SLF && Mainnet DMF (Mainnet representation of Arbitrum yields)
      - B-Tier CCLM Pairs:
         - Alt-Networks SLFs && Arbitrum DMFs (Aggregation of alt-networks share token representations on Arbitrum, all distilled into the A-Tier CCLM Pair