### PR TITLE
Fix eETHExtension

### DIFF
--- a/src/modules/price-router/Extensions/EtherFi/eETHExtension.sol
+++ b/src/modules/price-router/Extensions/EtherFi/eETHExtension.sol
@@ -50,11 +50,10 @@ contract eEthExtension is Extension {
      * @return price of eETH in USD [USD/eETH]
      */
     function getPriceInUSD(ERC20) external view override returns (uint256) {
-        // get price: [USD/eETH] =  [weETH / eETH] * [USD/weETH]
         return
-            IRateProvider(address(weETH)).getRate().mulDivDown(
-                priceRouter.getPriceInUSD(weETH),
-                10 ** weETH.decimals()
+            priceRouter.getPriceInUSD(weETH).mulDivDown(
+                10 ** weETH.decimals(),
+                IRateProvider(address(weETH)).getRate()
             );
     }
 }

--- a/test/testPriceRouter/eETHExtension.t.sol
+++ b/test/testPriceRouter/eETHExtension.t.sol
@@ -22,7 +22,7 @@ contract eEthExtensionTest is MainnetStarterTest, AdaptorHelperFunctions {
     function setUp() external {
         // Setup forked environment.
         string memory rpcKey = "MAINNET_RPC_URL";
-        uint256 blockNumber = 19085018;
+        uint256 blockNumber = 19277858;
         _startFork(rpcKey, blockNumber);
 
         // Run Starter setUp code.
@@ -41,13 +41,18 @@ contract eEthExtensionTest is MainnetStarterTest, AdaptorHelperFunctions {
 
         // Add eETH.
         uint256 weEthToEEthConversion = IRateProvider(address(WEETH)).getRate(); // [weETH / eETH]
-        price = weEthToEEthConversion.mulDivDown(price, 10 ** WEETH.decimals());
+
+        price = price.mulDivDown(
+                10 ** weETH.decimals(),
+                IRateProvider(address(WEETH)).getRate()
+            );
+
         settings = PriceRouter.AssetSettings(EXTENSION_DERIVATIVE, address(eethExtension));
         priceRouter.addAsset(EETH, settings, abi.encode(0), price);
 
         // check getValue()
         assertApproxEqRel(
-            priceRouter.getValue(EETH, 1e18, WEETH), // should be [WEETH / EETH]
+            priceRouter.getValue(WEETH, 1e18, EETH), 
             weEthToEEthConversion,
             1e8,
             "WEETH value in EETH should approx equal conversion."


### PR DESCRIPTION
As per conversations with Crispy, there was a bug in eETH extension. This has been caught and reviewed with external auditors, and pricing using this extension code has been revised before this fix. This fix reflects those changes.

Deployment that was corrected before this PR (so it is good): https://etherscan.io/address/0xE5Dc10b6474D6Ac66388d946F2E6B91E4759B8AC#code 

The problem was that `getPriceInUSD` was multiplying the weETH price by the eETH/weETH rate, when it really needs to be dividing out the rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the logic for calculating `eETH` prices in USD to ensure more accurate pricing for `eETH` assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->