### PR TITLE
replace Owned with Auth

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,8 +3,36 @@
 # This overrides the `auto_detect_solc` value
 solc_version = '0.8.21'
 auto_detect_solc = false
-
 evm_version = 'shanghai'
-# eth_rpc_url = "YOUR_ALCHEMY_HTTPS_URL_HERE"
-# etherscan_api_key = "YOUR_ETHERSCAN_API_KEY_HERE"
-block_number = 16869780
+optimizer = true
+optimizer_runs = 200
+
+[rpc_endpoints]
+mainnet = "${MAINNET_RPC_URL}"
+polygon = "${MATIC_RPC_URL}"
+bsc = "${BNB_RPC_URL}"
+avalanche = "${AVALANCHE_RPC_URL}"
+arbitrum = "${ARBITRUM_RPC_URL}"
+optimism = "${OPTIMISM_RPC_URL}"
+base = "${BASE_RPC_URL}"
+
+# [etherscan]
+# mainnet = { key = "${ETHERSCAN_KEY}", url = "https://api.etherscan.io/api" }
+# polygon = { key = "${POLYGONSCAN_KEY}" }
+# bsc = { key = "${BSCSCAN_KEY}" }
+# avalanche = { key = "${SNOWTRACE_KEY}" }
+# arbitrum = { key = "${ARBISCAN_KEY}" }
+# optimism = { key = "${OPTIMISMSCAN_KEY}" }
+# base = { key = "${BASESCAN_KEY}" }
+
+[fmt]
+FOUNDRY_FMT_LINE_LENGTH = 120
+FOUNDRY_FMT_TAB_WIDTH = 4
+FOUNDRY_FMT_BRACKET_SPACING = true
+FOUNDRY_FMT_INT_TYPES = "long"
+FOUNDRY_FMT_MULTILINE_FUNC_HEADER = "attributes_first"
+FOUNDRY_FMT_QUOTE_STYLE = "double"
+FOUNDRY_FMT_NUMBER_UNDERSCORE = "thousands"
+FOUNDRY_FMT_OVERRIDE_SPACING = true
+FOUNDRY_FMT_WRAP_COMMENTS = false
+FOUNDRY_FMT_IGNORE = []

--- a/resources/ContractDeploymentNames.sol
+++ b/resources/ContractDeploymentNames.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+contract ContractDeploymentNames {
+    // Infrastructure
+    string public registryName = "Registry V0.0";
+    string public priceRouterName = "PriceRouter V0.1";
+    string public timelockOwnerName = "Timelock Owner V0.0";
+    string public protocolFeeCollectorName = "Protocol Fee Collector V0.0";
+    string public feesAndReservesName = "Fees And Reserves V0.0";
+    string public withdrawQueueName = "Withdraw Queue V0.0";
+    string public simpleSolverName = "Simple Solver V0.0";
+    string public atomicQueueName = "Atomic Queue V0.0";
+    string public incentiveDistributorName = "Incentive Distributor V0.1";
+    // Adaptors
+    string public erc20AdaptorName = "ERC20 Adaptor V0.0";
+    string public erc4626AdaptorName = "ERC4626 Adaptor V0.0";
+    string public oneInchAdaptorName = "1Inch Adaptor V0.0";
+    string public zeroXAdaptorName = "0x Adaptor V0.0";
+    string public uniswapV3AdaptorName = "Uniswap V3 Adaptor V0.0";
+    string public uniswapV3PositionTrackerName = "Uniswap V3 Position Tracker V0.0";
+    string public swapWithUniswapAdaptorName = "Swap With Uniswap Adaptor V0.0";
+    string public aaveV3ATokenAdaptorName = "Aave V3 AToken Adaptor V0.0";
+    string public aaveV3DebtTokenAdaptorName = "Aave V3 Debt Token Adaptor V0.0";
+    string public compoundV3SupplyAdaptorName = "Compound V3 Supply Adaptor V 0.0";
+    string public compoundV3RewardsAdaptorName = "Compound V3 Rewards Adaptor V 0.0";
+    string public feesAndReservesAdaptorName = "Fees And Reserves Adaptor V 0.0";
+    string public balancerPoolAdaptorName = "Balancer Pool Adaptor V 0.0";
+    // Deploy below only after it has been confirmed that they will work on L2
+    string public balancerV2PoolAdaptorName = "Balancer Pool Adaptor V 0.0";
+    string public auraAdaptorName = "Aura ERC4626 Adaptor V 0.0";
+    string public curveAdaptorName = "Curve Adaptor V 0.0";
+    string public convexCurveAdaptorName = "Convex Curve Adaptor V 0.0";
+
+    // Vault Names
+    string public realYieldUsdName = "Real Yield USD V0.0";
+    string public realYieldEthName = "Real Yield ETH V0.1";
+    string public realYieldMaticName = "Real Yield MATIC V0.0";
+    string public realYieldAvaxName = "Real Yield AVAX V0.0";
+    string public turboRSETHName = "Turbo RSETH V0.0";
+    string public turboEZETHName = "Turbo EZETH V0.0";
+
+    // Share Price Oracle Names
+    string public realYieldUsdSharePriceOracleName = "Real Yield USD Share Price Oracle V0.0";
+    string public realYieldEthSharePriceOracleName = "Real Yield ETH Share Price Oracle V0.1";
+    string public realYieldMaticSharePriceOracleName = "Real Yield MATIC Share Price Oracle V0.0";
+    string public realYieldAvaxSharePriceOracleName = "Real Yield AVAX Share Price Oracle V0.0";
+
+    // Cellar Staking Contracts
+    string public realYieldUsdStakingName = "Real Yield USD Staking V0.0";
+    string public realYieldEthStakingName = "Real Yield ETH Staking V0.1";
+    // Mainnet
+    // TODO morpho adaptors
+    // aave v2 adaptors
+
+    // PRODUCTION_REGISTRY_V3 = {
+    // ERC20_ADAPTOR_NAME: "0xa5D315eA3D066160651459C4123ead9264130BFd",
+    // UNIV3_ADAPTOR_NAME: "0xC74fFa211A8148949a77ec1070Df7013C8D5Ce92",
+    // ONE_INCH_ADAPTOR_NAME: "0xB8952ce4010CFF3C74586d712a4402285A3a3AFb",
+    // ZEROX_ADAPTOR_NAME: "0x1039a9b61DFF6A3fb8dbF4e924AA749E5cFE35ef",
+    // SWAP_WITH_UNISWAP_ADAPTOR_NAME: "0xd6BC6Df1ed43e3101bC27a4254593a06598a3fDD",
+    // f"{BALANCER_POOL_ADAPTOR_NAME} (Deprecated)": "0xa05322534381D371Bf095E031D939f54faA33823",
+    // FEES_AND_RESERVES_ADAPTOR_NAME: "0x647d264d800A2461E594796af61a39b7735d8933",
+    // MORPHO_AAVEV2_ATOKEN_ADAPTOR_NAME: "0xD11142d10f4E5f12A97E6702cc43E598dC77B2D6",
+    // MORPHO_AAVEV3_P2P_ADAPTOR_NAME: "0x0Dd5d6bA17f223b51f46D4Ed5231cFBf929cFdEe",
+    // AAVEV3_ATOKEN_ADAPTOR_NAME: "0x76Cef5606C8b6bA38FE2e3c639E1659afA530b47",
+    // AAVEV3_DEBTTOKEN_ADAPTOR_NAME: "0x6DEd49176a69bEBf8dC1a4Ea357faa555df188f7",
+    // MORPHO_AAVEV2_DEBTTOKEN_ADAPTOR_NAME: "0x407D5489F201013EE6A6ca20fCcb05047C548138",
+    // LEGACY_CELLAR_ADAPTOR_NAME: "0x1e22aDf9E63eF8F2A3626841DDdDD19683E31068",
+    // VESTING_SIMPLE_ADAPTOR_NAME: "0x3b98BA00f981342664969e609Fb88280704ac479",
+    // AAVE_ATOKEN_ADAPTOR_NAME: "0xe3A3b8AbbF3276AD99366811eDf64A0a4b30fDa2",
+    // AAVE_DEBTTOKEN_ADAPTOR_NAME: "0xeC86ac06767e911f5FdE7cba5D97f082C0139C01",
+    // MORPHO_AAVEV3_ATOKEN_ADAPTOR_NAME: "0xB46E8a03b1AaFFFb50f281397C57b5B87080363E",
+    // MORPHO_AAVEV3_DEBTTOKEN_ADAPTOR_NAME: "0x25a61f771aF9a38C10dDd93c2bBAb39a88926fa9",
+    // f"{AAVE_ATOKEN_ADAPTOR_NAME} 1.02HF": "0x76282f60d541Ec41b26ac8fC0F6922337ADE0a86",
+    // f"{AAVE_DEBTTOKEN_ADAPTOR_NAME} 1.02HF": "0x1de3C2790E958BeDe9cA26e93169dBDfEF5A94B2",
+    // f"{AAVEV3_ATOKEN_ADAPTOR_NAME} 1.02HF": "0x96916a05c09f78B831c7bfC6e10e991A6fbeE1B3",
+    // f"{AAVEV3_DEBTTOKEN_ADAPTOR_NAME} 1.02HF": "0x0C74c849cC9aaACDe78d8657aBD6812C675726Fb",
+    // f"{MORPHO_AAVEV2_ATOKEN_ADAPTOR_NAME} 1.02HF": "0xD8224b856DdB3227CC0dCCb59BCBB5236651E25F",
+    // f"{MORPHO_AAVEV2_DEBTTOKEN_ADAPTOR_NAME} 1.02HF": "0xc852e0835eFaFeEF3B4d5bfEF41AA52D0E4eeD98",
+    // f"{MORPHO_AAVEV3_ATOKEN_ADAPTOR_NAME} 1.02HF": "0x84E7ea073bFd8c409678dBd17EC481dC9AD7Dcd9",
+    // f"{MORPHO_AAVEV3_DEBTTOKEN_ADAPTOR_NAME} 1.02HF": "0xf7C64ED003C997BD88DC5f1081eFBBE607400Df0",
+    // BALANCER_POOL_ADAPTOR_NAME: "0x2750348A897059C45683d33A1742a3989454F7d6",
+    // f"{VESTING_SIMPLE_ADAPTOR_NAME} SOMM": "0x8a95BBAbb0039480F6DD90fe856c1E0c3D575aA1",
+    // CELLAR_ADAPTOR_NAME: "0x3B5CA5de4d808Cd793d3a7b3a731D3E67E707B27",
+    // AAVE_ENABLE_ASSET_AS_COLLATERAL_ADAPTOR_NAME: "0x724FEb5819D1717Aec5ADBc0974a655a498b2614",
+    // }
+}

--- a/resources/PositionIds.sol
+++ b/resources/PositionIds.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+contract PositionIds {
+    uint32 public constant ERC20_USDC_POSITION = 1;
+    uint32 public constant ERC20_USDCE_POSITION = 2;
+    uint32 public constant ERC20_DAI_POSITION = 3;
+    uint32 public constant ERC20_USDT_POSITION = 4;
+    uint32 public constant ERC20_LUSD_POSITION = 5;
+    uint32 public constant ERC20_FRAX_POSITION = 6;
+    uint32 public constant ERC20_WETH_POSITION = 7;
+    uint32 public constant ERC20_WSTETH_POSITION = 8;
+    uint32 public constant ERC20_RETH_POSITION = 9;
+    uint32 public constant AAVE_V3_LOW_HF_A_USDC_POSITION = 10;
+    uint32 public constant AAVE_V3_LOW_HF_A_USDCE_POSITION = 11;
+    uint32 public constant AAVE_V3_LOW_HF_A_DAI_POSITION = 12;
+    uint32 public constant AAVE_V3_LOW_HF_A_USDT_POSITION = 13;
+    uint32 public constant AAVE_V3_LOW_HF_A_LUSD_POSITION = 14;
+    uint32 public constant AAVE_V3_LOW_HF_A_FRAX_POSITION = 15;
+    uint32 public constant AAVE_V3_LOW_HF_A_WETH_POSITION = 16;
+    uint32 public constant AAVE_V3_LOW_HF_A_WSTETH_POSITION = 17;
+    uint32 public constant AAVE_V3_LOW_HF_A_RETH_POSITION = 18;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_USDC_POSITION = 19;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_USDCE_POSITION = 20;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_DAI_POSITION = 21;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_USDT_POSITION = 22;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_LUSD_POSITION = 23;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_FRAX_POSITION = 24;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_WETH_POSITION = 25;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_WSTETH_POSITION = 26;
+    uint32 public constant AAVE_V3_LOW_HF_DEBT_RETH_POSITION = 27;
+    uint32 public constant UNISWAP_V3_USDC_USDCE_POSITION = 28;
+    uint32 public constant UNISWAP_V3_USDC_DAI_POSITION = 29;
+    uint32 public constant UNISWAP_V3_USDC_USDT_POSITION = 30;
+    uint32 public constant UNISWAP_V3_USDC_LUSD_POSITION = 31;
+    uint32 public constant UNISWAP_V3_USDC_FRAX_POSITION = 32;
+    uint32 public constant UNISWAP_V3_USDCE_DAI_POSITION = 33;
+    uint32 public constant UNISWAP_V3_USDCE_USDT_POSITION = 34;
+    uint32 public constant UNISWAP_V3_USDCE_LUSD_POSITION = 35;
+    uint32 public constant UNISWAP_V3_USDCE_FRAX_POSITION = 36;
+    uint32 public constant UNISWAP_V3_DAI_USDT_POSITION = 37;
+    uint32 public constant UNISWAP_V3_DAI_LUSD_POSITION = 38;
+    uint32 public constant UNISWAP_V3_DAI_FRAX_POSITION = 39;
+    uint32 public constant UNISWAP_V3_USDT_LUSD_POSITION = 40;
+    uint32 public constant UNISWAP_V3_USDT_FRAX_POSITION = 41;
+    uint32 public constant UNISWAP_V3_LUSD_FRAX_POSITION = 42;
+    uint32 public constant UNISWAP_V3_WETH_WSTETH_POSITION = 43;
+    uint32 public constant UNISWAP_V3_WETH_RETH_POSITION = 44;
+    uint32 public constant UNISWAP_V3_WSTETH_RETH_POSITION = 45;
+    uint32 public constant COMPOUND_V3_SUPPLY_USDC_POSITION = 46;
+    uint32 public constant COMPOUND_V3_SUPPLY_USDCE_POSITION = 47;
+}

--- a/script/Mainnet/production/SetUpArchitecture.s.sol
+++ b/script/Mainnet/production/SetUpArchitecture.s.sol
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import {Deployer} from "src/Deployer.sol";
+import {Registry} from "src/Registry.sol";
+import {PriceRouter} from "src/modules/price-router/PriceRouter.sol";
+import {ERC20Adaptor} from "src/modules/adaptors/ERC20Adaptor.sol";
+import {SwapWithUniswapAdaptor} from "src/modules/adaptors/Uniswap/SwapWithUniswapAdaptor.sol";
+import {UniswapV3PositionTracker} from "src/modules/adaptors/Uniswap/UniswapV3PositionTracker.sol";
+import {UniswapV3Adaptor} from "src/modules/adaptors/Uniswap/UniswapV3Adaptor.sol";
+import {OneInchAdaptor} from "src/modules/adaptors/OneInch/OneInchAdaptor.sol";
+import {ZeroXAdaptor} from "src/modules/adaptors/ZeroX/ZeroXAdaptor.sol";
+import {IChainlinkAggregator} from "src/interfaces/external/IChainlinkAggregator.sol";
+import {UniswapV3Pool} from "src/interfaces/external/UniswapV3Pool.sol";
+import {CurveAdaptor} from "src/modules/adaptors/Curve/CurveAdaptor.sol";
+import {ConvexCurveAdaptor} from "src/modules/adaptors/Convex/ConvexCurveAdaptor.sol";
+import {BalancerPoolAdaptor, SafeTransferLib} from "src/modules/adaptors/Balancer/BalancerPoolAdaptor.sol";
+import {AuraERC4626Adaptor} from "src/modules/adaptors/Aura/AuraERC4626Adaptor.sol";
+import {INonfungiblePositionManager} from "@uniswapV3P/interfaces/INonfungiblePositionManager.sol";
+import {MorphoBlueSupplyAdaptor} from "src/modules/adaptors/Morpho/MorphoBlue/MorphoBlueSupplyAdaptor.sol";
+import {MorphoBlueDebtAdaptor} from "src/modules/adaptors/Morpho/MorphoBlue/MorphoBlueDebtAdaptor.sol";
+import {MorphoBlueCollateralAdaptor} from "src/modules/adaptors/Morpho/MorphoBlue/MorphoBlueCollateralAdaptor.sol";
+import {EtherFiStakingAdaptor} from "src/modules/adaptors/Staking/EtherFiStakingAdaptor.sol";
+import {
+    RedstoneEthPriceFeedExtension,
+    IRedstoneAdapter
+} from "src/modules/price-router/Extensions/Redstone/RedstoneEthPriceFeedExtension.sol";
+import {eEthExtension} from "src/modules/price-router/Extensions/EtherFi/eEthExtension.sol";
+import {
+    BalancerStablePoolExtension,
+    IVault
+} from "src/modules/price-router/Extensions/Balancer/BalancerStablePoolExtension.sol";
+import {IMorpho, MarketParams, Id, Market} from "src/interfaces/external/Morpho/MorphoBlue/interfaces/IMorpho.sol";
+import {CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport} from
+    "src/base/permutations/advanced/CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport.sol";
+import {ContractDeploymentNames} from "resources/ContractDeploymentNames.sol";
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ERC4626SharePriceOracle} from "src/base/ERC4626SharePriceOracle.sol";
+import {FeesAndReservesAdaptor} from "src/modules/adaptors/FeesAndReserves/FeesAndReservesAdaptor.sol";
+import {FeesAndReserves} from "src/modules/FeesAndReserves.sol";
+import {ProtocolFeeCollector} from "src/modules/ProtocolFeeCollector.sol";
+import {PositionIds} from "resources/PositionIds.sol";
+import {Math} from "src/utils/Math.sol";
+import {RolesAuthority, Authority} from "@solmate/auth//authorities/RolesAuthority.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+interface IMB {
+    function idToMarketParams(bytes32 id) external view returns (MarketParams memory);
+}
+/**
+ *  source .env && forge script script/Mainnet/production/SetUpArchitecture.s.sol:SetUpArchitectureScript --evm-version london --with-gas-price 60000000000 --slow --broadcast --etherscan-api-key $MAINNET_RPC_URL --verify
+ * @dev Optionally can change `--with-gas-price` to something more reasonable
+ */
+
+contract SetUpArchitectureScript is Script, MainnetAddresses, ContractDeploymentNames, PositionIds {
+    using SafeTransferLib for ERC20;
+    using Math for uint256;
+    using stdJson for string;
+
+    uint256 public privateKey;
+    Registry public registry;
+    PriceRouter public priceRouter;
+    address public erc20Adaptor;
+    address public swapWithUniswapAdaptor;
+    address public uniswapV3Adaptor;
+    address public curveAdaptor;
+    address public convexCurveAdaptor;
+    address public balancerPoolAdaptor;
+    address public auraERC4626Adaptor;
+    address public oneInchAdaptor;
+    address public zeroXAdaptor;
+    address public morphoBlueSupplyAdaptor;
+    address public morphoBlueDebtAdaptor;
+    address public morphoBlueCollateralAdaptor;
+    address public etherFiStakingAdaptor;
+    address public redstoneEthPriceFeedExtension;
+    address public eEthExtensionAddress;
+    address public balancerStablePoolExtension;
+    uint256 public constant AAVE_V3_MIN_HEALTH_FACTOR = 1.01e18;
+    address public feesAndReservesAdaptor;
+    address public feesAndReserves;
+    address public protocolFeeCollector;
+    address public rolesAuthority;
+
+    IMB morphoBlue = IMB(0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb);
+
+    CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport public pepeEth;
+
+    uint8 public constant CHAINLINK_DERIVATIVE = 1;
+    uint8 public constant TWAP_DERIVATIVE = 2;
+    uint8 public constant EXTENSION_DERIVATIVE = 3;
+
+    uint256 expectedWeEthPriceInUsd8Decimals = 3_996e8;
+    uint256 expectedEEthPriceInUsd8Decimals = 3_869e8;
+    // uint256 currentPriceOfOneWethWeethBptWith8Decimals = 3_883e8;
+    // uint256 currentPriceOfOneRethWeethBptWith8Decimals = 3_883e8;
+
+    bytes32 public weEthWethMarketId = 0x698fe98247a40c5771537b5786b2f3f9d78eb487b4ce4d75533cd0e94d88a115;
+
+    address public devOwner = 0x59bAE9c3d121152B27A2B5a46bD917574Ca18142;
+
+    function setUp() external {
+        privateKey = vm.envUint("SEVEN_SEAS_PRIVATE_KEY");
+    }
+
+    function run() external {
+        bytes memory creationCode;
+        bytes memory constructorArgs;
+        vm.createSelectFork("mainnet");
+        vm.startBroadcast(privateKey);
+        // Deploy Registry
+        registry = new Registry(devOwner, devOwner, address(0), address(0));
+
+        // Deploy Price Router
+        priceRouter = new PriceRouter(devOwner, registry, WETH);
+
+        // Update price router in registry.
+        registry.setAddress(2, address(priceRouter));
+
+        // Deploy ERC20Adaptor.
+        erc20Adaptor = address(new ERC20Adaptor());
+
+        // Deploy SwapWithUniswapAdaptor.
+        swapWithUniswapAdaptor = address(new SwapWithUniswapAdaptor(uniV2Router, uniV3Router));
+
+        // Deploy Uniswap V3 Adaptor.
+        address tracker = address(new UniswapV3PositionTracker(INonfungiblePositionManager(uniswapV3PositionManager)));
+
+        creationCode = type(UniswapV3Adaptor).creationCode;
+        constructorArgs = abi.encode(uniswapV3PositionManager, tracker);
+        uniswapV3Adaptor = address(new UniswapV3Adaptor(uniswapV3PositionManager, tracker));
+
+        // Deploy Balancer/Aura Adaptors.
+        balancerPoolAdaptor = address(new BalancerPoolAdaptor(vault, minter, 0.9e4));
+
+        auraERC4626Adaptor = address(new AuraERC4626Adaptor());
+
+        // Deploy 1Inch Adaptor.
+        oneInchAdaptor = address(new OneInchAdaptor(oneInchTarget));
+
+        // Deploy 0x Adaptor.
+        zeroXAdaptor = address(new ZeroXAdaptor(zeroXTarget));
+
+        // Deploy morpho blue adaptors
+        morphoBlueSupplyAdaptor = address(new MorphoBlueSupplyAdaptor(_morphoBlue));
+        morphoBlueDebtAdaptor = address(new MorphoBlueDebtAdaptor(_morphoBlue, 1.01e18));
+        morphoBlueCollateralAdaptor = address(new MorphoBlueCollateralAdaptor(_morphoBlue, 1.01e18));
+
+        // Deploy etherfi staking adaptor
+        etherFiStakingAdaptor = address(
+            new EtherFiStakingAdaptor(
+                address(WETH), 8, liquidityPool, withdrawalRequestNft, address(WEETH), address(EETH)
+            )
+        );
+
+        // TODO deploy fees and reserves.
+        protocolFeeCollector = address(new ProtocolFeeCollector(devOwner));
+
+        feesAndReserves = address(
+            new FeesAndReserves(
+                protocolFeeCollector,
+                0x02777053d6764996e594c3E88AF1D58D5363a2e6,
+                0x169E633A2D1E6c10dD91238Ba11c4A708dfEF37C
+            )
+        );
+        feesAndReservesAdaptor = address(new FeesAndReservesAdaptor(feesAndReserves));
+        // Trust Adaptors in Registry.
+        registry.trustAdaptor(erc20Adaptor);
+        registry.trustAdaptor(swapWithUniswapAdaptor);
+        registry.trustAdaptor(uniswapV3Adaptor);
+        registry.trustAdaptor(balancerPoolAdaptor);
+        registry.trustAdaptor(auraERC4626Adaptor);
+        registry.trustAdaptor(oneInchAdaptor);
+        registry.trustAdaptor(zeroXAdaptor);
+        registry.trustAdaptor(morphoBlueSupplyAdaptor);
+        registry.trustAdaptor(morphoBlueDebtAdaptor);
+        registry.trustAdaptor(morphoBlueCollateralAdaptor);
+        registry.trustAdaptor(etherFiStakingAdaptor);
+        registry.trustAdaptor(feesAndReservesAdaptor);
+        // registry.trustAdaptor(curveAdaptor);
+        // registry.trustAdaptor(convexCurveAdaptor);
+
+        // Deploy Pricing Extensions.
+        redstoneEthPriceFeedExtension = address(new RedstoneEthPriceFeedExtension(priceRouter, address(WETH)));
+        eEthExtensionAddress = address(new eEthExtension(priceRouter));
+        balancerStablePoolExtension = address(new BalancerStablePoolExtension(priceRouter, IVault(vault)));
+
+        // Add pricing.
+        PriceRouter.ChainlinkDerivativeStorage memory stor;
+        PriceRouter.AssetSettings memory settings;
+
+        uint256 price = uint256(IChainlinkAggregator(WETH_USD_FEED).latestAnswer());
+        settings = PriceRouter.AssetSettings(CHAINLINK_DERIVATIVE, WETH_USD_FEED);
+        priceRouter.addAsset(WETH, settings, abi.encode(stor), price);
+
+        stor.inETH = true;
+
+        price = uint256(IChainlinkAggregator(RETH_ETH_FEED).latestAnswer());
+        price = price.mulDivDown(priceRouter.getPriceInUSD(WETH), 1e18);
+        settings = PriceRouter.AssetSettings(CHAINLINK_DERIVATIVE, RETH_ETH_FEED);
+        priceRouter.addAsset(rETH, settings, abi.encode(stor), price);
+
+        RedstoneEthPriceFeedExtension.ExtensionStorage memory rstor;
+        rstor.dataFeedId = weEthDataFeedId;
+        rstor.heartbeat = 1 days;
+        rstor.redstoneAdapter = IRedstoneAdapter(weEthEthAdapter);
+        settings = PriceRouter.AssetSettings(EXTENSION_DERIVATIVE, redstoneEthPriceFeedExtension);
+        priceRouter.addAsset(WEETH, settings, abi.encode(rstor), expectedWeEthPriceInUsd8Decimals);
+
+        settings = PriceRouter.AssetSettings(EXTENSION_DERIVATIVE, eEthExtensionAddress);
+        priceRouter.addAsset(EETH, settings, hex"", expectedEEthPriceInUsd8Decimals);
+
+        // TODO Add Balancer pricing
+        // BalancerStablePoolExtension.ExtensionStorage memory bstor;
+
+        // bstor = BalancerStablePoolExtension.ExtensionStorage({
+        //     poolId: 0xb9debddf1d894c79d2b2d09f819ff9b856fca55200000000000000000000062a,
+        //     poolDecimals: 18,
+        //     rateProviderDecimals: [uint8(0), 18, 0, 0, 0, 0, 0, 0],
+        //     rateProviders: [
+        //         address(0),
+        //         address(WEETH),
+        //         address(0),
+        //         address(0),
+        //         address(0),
+        //         address(0),
+        //         address(0),
+        //         address(0)
+        //     ],
+        //     underlyingOrConstituent: [
+        //         WETH,
+        //         WEETH,
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0))
+        //     ]
+        // });
+
+        // settings = PriceRouter.AssetSettings({derivative: EXTENSION_DERIVATIVE, source: balancerStablePoolExtension});
+
+        // priceRouter.addAsset(wEth_weETH_bpt, settings, abi.encode(bstor), currentPriceOfOneWethWeethBptWith8Decimals);
+
+        // bstor = BalancerStablePoolExtension.ExtensionStorage({
+        //     poolId: 0x05ff47afada98a98982113758878f9a8b9fdda0a000000000000000000000645,
+        //     poolDecimals: 18,
+        //     rateProviderDecimals: [uint8(18), 18, 0, 0, 0, 0, 0, 0],
+        //     rateProviders: [
+        //         0x1a8F81c256aee9C640e14bB0453ce247ea0DFE6F,
+        //         address(WEETH),
+        //         address(0),
+        //         address(0),
+        //         address(0),
+        //         address(0),
+        //         address(0),
+        //         address(0)
+        //     ],
+        //     underlyingOrConstituent: [
+        //         rETH,
+        //         WEETH,
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0)),
+        //         ERC20(address(0))
+        //     ]
+        // });
+
+        // settings = PriceRouter.AssetSettings({derivative: EXTENSION_DERIVATIVE, source: balancerStablePoolExtension});
+
+        // priceRouter.addAsset(rETH_weETH_bpt, settings, abi.encode(bstor), currentPriceOfOneRethWeethBptWith8Decimals);
+
+        // TODO Add curve pricing
+
+        registry.trustPosition(1, address(erc20Adaptor), abi.encode(WETH));
+        registry.trustPosition(2, address(erc20Adaptor), abi.encode(EETH));
+        registry.trustPosition(3, address(erc20Adaptor), abi.encode(WEETH));
+
+        registry.trustPosition(
+            4, address(uniswapV3Adaptor), abi.encode(address(WETH) < address(WEETH) ? [WETH, WEETH] : [WEETH, WETH])
+        );
+        _checkTokenOrdering(4);
+
+        registry.trustPosition(
+            5, address(uniswapV3Adaptor), abi.encode(address(WEETH) < address(rETH) ? [WEETH, rETH] : [rETH, WEETH])
+        );
+        _checkTokenOrdering(5);
+
+        registry.trustPosition(
+            6, address(uniswapV3Adaptor), abi.encode(address(EETH) < address(WETH) ? [EETH, WETH] : [WETH, EETH])
+        );
+        _checkTokenOrdering(6);
+
+        registry.trustPosition(
+            7, address(uniswapV3Adaptor), abi.encode(address(EETH) < address(rETH) ? [EETH, rETH] : [rETH, EETH])
+        );
+        _checkTokenOrdering(7);
+
+        // Add Balancer positions
+        // TODO find the liquidity gauges
+        // registry.trustPosition(8, balancerPoolAdaptor, abi.encode(wEth_weETH_bpt, address(0)));
+        // registry.trustPosition(9, balancerPoolAdaptor, abi.encode(rETH_weETH_bpt, address(0)));
+        // Add Aura positions
+        // registry.trustPosition(10, auraERC4626Adaptor, abi.encode(aura_reth_weeth));
+
+        // Add morpho blue positions
+        MarketParams memory weEthWethMarket = morphoBlue.idToMarketParams(weEthWethMarketId);
+        // supply positions
+        registry.trustPosition(11, address(morphoBlueSupplyAdaptor), abi.encode(weEthWethMarket));
+
+        // collateral positions
+        registry.trustPosition(12, address(morphoBlueCollateralAdaptor), abi.encode(weEthWethMarket));
+
+        // borrow positions
+        registry.trustPosition(14, address(morphoBlueDebtAdaptor), abi.encode(weEthWethMarket));
+
+        ERC4626SharePriceOracle.ConstructorArgs memory args;
+        // Set all oracles to use 50 bps deviation, 5 day TWAAs with 8 hour grace period.
+        // Allowed answer change upper and lower of 1.25x and 0.75x
+        args._heartbeat = 1 days;
+        args._deviationTrigger = 0.005e4;
+        args._gracePeriod = 1 days / 3;
+        args._observationsToUse = 4;
+        args._automationRegistry = automationRegistryV2;
+        args._automationRegistrar = automationRegistrarV2;
+        args._automationAdmin = devOwner;
+        args._link = address(LINK);
+        args._startingAnswer = 1e18;
+        args._allowedAnswerChangeLower = 0.75e4;
+        args._allowedAnswerChangeUpper = 1.25e4;
+        args._sequencerUptimeFeed = address(0);
+        args._sequencerGracePeriod = 0;
+
+        pepeEth = _createCellarWithNativeSupport(
+            "PepeETH", // Name
+            "PEPEETH", // Symbol
+            WETH,
+            1,
+            abi.encode(true),
+            0.0001e18,
+            0.5e18
+        );
+
+        args._target = pepeEth;
+        _createSharePriceOracle(args);
+
+        args._heartbeat = 300;
+        args._gracePeriod = 30 days;
+
+        _createSharePriceOracle(args);
+
+        pepeEth.addAdaptorToCatalogue(erc20Adaptor);
+        pepeEth.addAdaptorToCatalogue(swapWithUniswapAdaptor);
+        pepeEth.addAdaptorToCatalogue(uniswapV3Adaptor);
+        pepeEth.addAdaptorToCatalogue(balancerPoolAdaptor);
+        pepeEth.addAdaptorToCatalogue(auraERC4626Adaptor);
+        pepeEth.addAdaptorToCatalogue(oneInchAdaptor);
+        pepeEth.addAdaptorToCatalogue(zeroXAdaptor);
+        pepeEth.addAdaptorToCatalogue(morphoBlueSupplyAdaptor);
+        pepeEth.addAdaptorToCatalogue(morphoBlueDebtAdaptor);
+        pepeEth.addAdaptorToCatalogue(morphoBlueCollateralAdaptor);
+        pepeEth.addAdaptorToCatalogue(etherFiStakingAdaptor);
+        pepeEth.addAdaptorToCatalogue(feesAndReservesAdaptor);
+
+        pepeEth.addPositionToCatalogue(2);
+        pepeEth.addPositionToCatalogue(3);
+        pepeEth.addPositionToCatalogue(4);
+        pepeEth.addPositionToCatalogue(5);
+        pepeEth.addPositionToCatalogue(6);
+        pepeEth.addPositionToCatalogue(7);
+        // pepeEth.addPositionToCatalogue(8);
+        // pepeEth.addPositionToCatalogue(9);
+        // pepeEth.addPositionToCatalogue(10);
+        pepeEth.addPositionToCatalogue(11);
+        pepeEth.addPositionToCatalogue(12);
+        pepeEth.addPositionToCatalogue(14);
+
+        // Deploy RolesAuthority
+        rolesAuthority = address(new RolesAuthority(devOwner, Authority(address(0))));
+
+        vm.stopBroadcast();
+    }
+
+    function _checkTokenOrdering(uint32 registryId) internal view {
+        (,, bytes memory data,) = registry.getPositionIdToPositionData(registryId);
+        (address token0, address token1) = abi.decode(data, (address, address));
+        if (token1 < token0) revert("Tokens out of order");
+        UniswapV3Pool pool = IUniswapV3Factory(uniswapV3Factory).getPool(token0, token1, 100);
+        if (address(pool) == address(0)) pool = IUniswapV3Factory(uniswapV3Factory).getPool(token0, token1, 500);
+        if (address(pool) == address(0)) pool = IUniswapV3Factory(uniswapV3Factory).getPool(token0, token1, 3000);
+        if (address(pool) != address(0)) {
+            if (pool.token0() != token0) revert("Token 0 mismtach");
+            if (pool.token1() != token1) revert("Token 1 mismtach");
+        }
+    }
+
+    function _createSharePriceOracle(ERC4626SharePriceOracle.ConstructorArgs memory args)
+        internal
+        returns (ERC4626SharePriceOracle)
+    {
+        return new ERC4626SharePriceOracle(args);
+    }
+
+    function _createCellarWithNativeSupport(
+        string memory cellarName,
+        string memory cellarSymbol,
+        ERC20 holdingAsset,
+        uint32 holdingPosition,
+        bytes memory holdingPositionConfig,
+        uint256 initialDeposit,
+        uint64 platformCut
+    ) internal returns (CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport) {
+        // Approve new cellar to spend assets.
+        address cellarAddress = 0xD70e70f50365b3b14CB62225BeCdF1d9e893a660;
+        holdingAsset.safeApprove(cellarAddress, initialDeposit);
+
+        return new CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport(
+            devOwner,
+            registry,
+            holdingAsset,
+            cellarName,
+            cellarSymbol,
+            holdingPosition,
+            holdingPositionConfig,
+            initialDeposit,
+            platformCut,
+            type(uint192).max,
+            address(vault)
+        );
+    }
+}
+
+interface IUniswapV3Factory {
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (UniswapV3Pool pool);
+}

--- a/src/Deployer.sol
+++ b/src/Deployer.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.21;
 
-import { Cellar, Owned, ERC20, SafeTransferLib, Address } from "src/base/Cellar.sol";
+import { Cellar, ERC20, SafeTransferLib, Address } from "src/base/Cellar.sol";
 import { CREATE3 } from "@solmate/utils/CREATE3.sol";
+import { Owned } from "@solmate/auth/Owned.sol";
 
 contract Deployer is Owned {
     mapping(address => bool) public isDeployer;

--- a/src/base/permutations/CellarWithMultiAssetDeposit.sol
+++ b/src/base/permutations/CellarWithMultiAssetDeposit.sol
@@ -110,7 +110,7 @@ contract CellarWithMultiAssetDeposit is Cellar {
         uint32 _alternativeHoldingPosition,
         uint32 _alternativeAssetFee
     ) external {
-        _onlyOwner();
+        _isAuthorized();
         if (!isPositionUsed[_alternativeHoldingPosition]) revert Cellar__PositionNotUsed(_alternativeHoldingPosition);
         if (_assetOf(_alternativeHoldingPosition) != _alternativeAsset)
             revert Cellar__AssetMismatch(address(_alternativeAsset), address(_assetOf(_alternativeHoldingPosition)));
@@ -134,7 +134,7 @@ contract CellarWithMultiAssetDeposit is Cellar {
      * @param _alternativeAsset the asset to not allow for alternative asset deposits anymore
      */
     function dropAlternativeAssetData(ERC20 _alternativeAsset) external {
-        _onlyOwner();
+        _isAuthorized();
         delete alternativeAssetData[_alternativeAsset];
 
         emit AlternativeAssetDropped(address(_alternativeAsset));

--- a/src/base/permutations/CellarWithOracle.sol
+++ b/src/base/permutations/CellarWithOracle.sol
@@ -60,7 +60,7 @@ contract CellarWithOracle is Cellar {
      * @dev Trying to set the share price oracle to the zero address will revert here.
      * @dev Callable by Sommelier Governance.
      */
-    function setSharePriceOracle(uint256 _registryId, ERC4626SharePriceOracle _sharePriceOracle) external onlyOwner {
+    function setSharePriceOracle(uint256 _registryId, ERC4626SharePriceOracle _sharePriceOracle) external requiresAuth {
         _checkRegistryAddressAgainstExpected(_registryId, address(_sharePriceOracle));
         if (_sharePriceOracle.decimals() != ORACLE_DECIMALS || address(_sharePriceOracle.target()) != address(this))
             revert Cellar__OracleFailure();

--- a/src/base/permutations/CellarWithShareLockPeriod.sol
+++ b/src/base/permutations/CellarWithShareLockPeriod.sol
@@ -81,7 +81,7 @@ contract CellarWithShareLockPeriod is Cellar {
      * @param newLock the new lock period
      * @dev Callable by Sommelier Strategist.
      */
-    function setShareLockPeriod(uint256 newLock) external onlyOwner {
+    function setShareLockPeriod(uint256 newLock) external requiresAuth {
         if (newLock < MINIMUM_SHARE_LOCK_PERIOD || newLock > MAXIMUM_SHARE_LOCK_PERIOD)
             revert Cellar__InvalidShareLockPeriod();
         uint256 oldLockingPeriod = shareLockPeriod;

--- a/src/base/permutations/advanced/CellarWithOracleWithAaveFlashLoansWithMultiAssetDeposit.sol
+++ b/src/base/permutations/advanced/CellarWithOracleWithAaveFlashLoansWithMultiAssetDeposit.sol
@@ -113,7 +113,7 @@ contract CellarWithOracleWithAaveFlashLoansWithMultiAssetDeposit is CellarWithOr
         uint32 _alternativeHoldingPosition,
         uint32 _alternativeAssetFee
     ) external {
-        _onlyOwner();
+        _isAuthorized();
         if (!isPositionUsed[_alternativeHoldingPosition]) revert Cellar__PositionNotUsed(_alternativeHoldingPosition);
         if (_assetOf(_alternativeHoldingPosition) != _alternativeAsset)
             revert Cellar__AssetMismatch(address(_alternativeAsset), address(_assetOf(_alternativeHoldingPosition)));
@@ -137,7 +137,7 @@ contract CellarWithOracleWithAaveFlashLoansWithMultiAssetDeposit is CellarWithOr
      * @param _alternativeAsset the asset to not allow for alternative asset deposits anymore
      */
     function dropAlternativeAssetData(ERC20 _alternativeAsset) external {
-        _onlyOwner();
+        _isAuthorized();
         delete alternativeAssetData[_alternativeAsset];
 
         emit AlternativeAssetDropped(address(_alternativeAsset));

--- a/src/base/permutations/advanced/CellarWithOracleWithBalancerFlashLoansWithMultiAssetDeposit.sol
+++ b/src/base/permutations/advanced/CellarWithOracleWithBalancerFlashLoansWithMultiAssetDeposit.sol
@@ -113,7 +113,7 @@ contract CellarWithOracleWithBalancerFlashLoansWithMultiAssetDeposit is CellarWi
         uint32 _alternativeHoldingPosition,
         uint32 _alternativeAssetFee
     ) external {
-        _onlyOwner();
+        _isAuthorized();
         if (!isPositionUsed[_alternativeHoldingPosition]) revert Cellar__PositionNotUsed(_alternativeHoldingPosition);
         if (_assetOf(_alternativeHoldingPosition) != _alternativeAsset)
             revert Cellar__AssetMismatch(address(_alternativeAsset), address(_assetOf(_alternativeHoldingPosition)));
@@ -137,7 +137,7 @@ contract CellarWithOracleWithBalancerFlashLoansWithMultiAssetDeposit is CellarWi
      * @param _alternativeAsset the asset to not allow for alternative asset deposits anymore
      */
     function dropAlternativeAssetData(ERC20 _alternativeAsset) external {
-        _onlyOwner();
+        _isAuthorized();
         delete alternativeAssetData[_alternativeAsset];
 
         emit AlternativeAssetDropped(address(_alternativeAsset));

--- a/src/modules/FeesAndReserves.sol
+++ b/src/modules/FeesAndReserves.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.21;
 
-import { Cellar, Owned, ERC20, SafeTransferLib, Math, Address } from "src/base/Cellar.sol";
+import { Cellar, ERC20, SafeTransferLib, Math, Address } from "src/base/Cellar.sol";
 import { IGravity } from "src/interfaces/external/IGravity.sol";
 import { AutomationCompatibleInterface } from "@chainlink/contracts/src/v0.8/interfaces/AutomationCompatibleInterface.sol";
 import { IChainlinkAggregator } from "src/interfaces/external/IChainlinkAggregator.sol";
 import { ReentrancyGuard } from "@solmate/utils/ReentrancyGuard.sol";
+import { Owned } from "@solmate/auth/Owned.sol";
 
 /**
  * @title Fees And Reserves

--- a/src/modules/ProtocolFeeCollector.sol
+++ b/src/modules/ProtocolFeeCollector.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.21;
 
-import { Owned, ERC20, SafeTransferLib } from "src/base/Cellar.sol";
+import { ERC20, SafeTransferLib } from "src/base/Cellar.sol";
+import { Owned } from "@solmate/auth/Owned.sol";
 
 /**
  * @title Protocol Fee Collector

--- a/test/resources/MainnetAddresses.sol
+++ b/test/resources/MainnetAddresses.sol
@@ -336,4 +336,13 @@ contract MainnetAddresses {
     address public cometRewards = 0x1B0e765F6224C21223AeA2af16c1C46E38885a40;
     // Morpho Blue
     address public _morphoBlue = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
+
+    address public uniswapV3PositionManager = 0xC36442b4a4522E871399CD717aBDD847Ab11FE88;
+    address public uniswapV3Factory = 0x1F98431c8aD98523631AE4a59f267346ea31F984;
+
+    // 1Inch
+    address public oneInchTarget = 0x1111111254EEB25477B68fb85Ed929f73A960582;
+
+    // 0x
+    address public zeroXTarget = 0xDef1C0ded9bec7F1a1670819833240f027b25EfF;
 }

--- a/test/testIntegrations/AuthCellar.t.sol
+++ b/test/testIntegrations/AuthCellar.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import {CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport} from
+    "src/base/permutations/advanced/CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport.sol";
+import {IChainlinkAggregator} from "src/interfaces/external/IChainlinkAggregator.sol";
+import {RolesAuthority, Authority} from "@solmate/auth//authorities/RolesAuthority.sol";
+import {Cellar} from "src/base/Cellar.sol";
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// Import Everything from Starter file.
+import "test/resources/MainnetStarter.t.sol";
+
+import {AdaptorHelperFunctions} from "test/resources/AdaptorHelperFunctions.sol";
+
+contract AuthCellarTest is MainnetStarterTest, AdaptorHelperFunctions {
+    using SafeTransferLib for ERC20;
+    using Math for uint256;
+    using stdStorage for StdStorage;
+    using Address for address;
+
+    CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport private cellar;
+    RolesAuthority private cellarAuthority;
+
+    uint32 private wethPosition = 1;
+
+    uint256 private initialAssets;
+    uint256 private initialShares;
+
+    function setUp() external {
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 16869780;
+        _startFork(rpcKey, blockNumber);
+        // Run Starter setUp code.
+        _setUp();
+
+        // Setup pricing
+        PriceRouter.ChainlinkDerivativeStorage memory stor;
+        PriceRouter.AssetSettings memory settings;
+        uint256 price = uint256(IChainlinkAggregator(WETH_USD_FEED).latestAnswer());
+        settings = PriceRouter.AssetSettings(CHAINLINK_DERIVATIVE, WETH_USD_FEED);
+        priceRouter.addAsset(WETH, settings, abi.encode(stor), price);
+
+        // Add adaptors and ERC20 positions to the registry.
+        registry.trustPosition(wethPosition, address(erc20Adaptor), abi.encode(WETH));
+
+        string memory cellarName = "Auth Cellar V0.0";
+        uint256 initialDeposit = 0.0011e18;
+        deal(address(WETH), address(this), initialDeposit);
+        WETH.approve(0x2e234DAe75C793f67A35089C9d99245E1C58470b, initialDeposit);
+        uint64 platformCut = 0.75e18;
+        cellar = new CellarWithOracleWithBalancerFlashLoansWithMultiAssetDepositWithNativeSupport(
+            address(this),
+            registry,
+            WETH,
+            cellarName,
+            "POG",
+            wethPosition,
+            abi.encode(true),
+            initialDeposit,
+            platformCut,
+            type(uint192).max,
+            vault
+        );
+
+        vm.label(multisig, "multisig");
+        vm.label(strategist, "strategist");
+        // Approve cellar to spend all assets.
+        USDC.approve(address(cellar), type(uint256).max);
+        initialAssets = cellar.totalAssets();
+        initialShares = cellar.totalSupply();
+
+        cellarAuthority = new RolesAuthority(address(this), Authority(address(0)));
+    }
+
+    function testAuth() external {
+        // Currently only the owner address can make any authorized calls.
+        vm.startPrank(strategist);
+        vm.expectRevert(bytes("UNAUTHORIZED"));
+        cellar.addPositionToCatalogue(wethPosition);
+        vm.stopPrank();
+
+        // In order to allow the strategist to do anything, we need to setup a new role for them, and give that roles all the permissions it needs.
+        uint8 strategistRole = 1;
+        cellarAuthority.setRoleCapability(strategistRole, address(cellar), Cellar.addPositionToCatalogue.selector, true);
+        cellarAuthority.setUserRole(strategist, strategistRole, true);
+
+        // Now the ownder of the cellar must set its authority.
+        cellar.setAuthority(cellarAuthority);
+
+        // The strategist is now able to call the authorized function.
+        vm.startPrank(strategist);
+        cellar.addPositionToCatalogue(wethPosition);
+        vm.stopPrank();
+
+        // The owner of the cellar has the option to either set the authority to the zero address to stop calls, or
+        // the owner of the authority can either remove the strategist from the role, or
+        // the owner can remove the `addPositionToCatalogue` privilege from the strategistRole.
+
+        cellarAuthority.setRoleCapability(
+            strategistRole, address(cellar), Cellar.addPositionToCatalogue.selector, false
+        );
+
+        vm.startPrank(strategist);
+        vm.expectRevert(bytes("UNAUTHORIZED"));
+        cellar.addPositionToCatalogue(wethPosition);
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
This PR replaces `Owned` in Cellar.sol with `Auth`. This allows us to run Cellars with the _exact same functionality as _before__ but optionally if an Authority is set by the owner of the Cellar, we can create up to 256 different roles, and give each of those roles a specific set of `Authorized` functions they can call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced naming conventions for various infrastructure components and financial instruments within the protocol for better clarity and organization.
	- Added a new contract setup script that establishes a comprehensive financial system architecture, including adaptors, extensions, oracles, and positions for a variety of protocols.
	- Enhanced the `Cellar` contract with authorization logic, improved fee structures, and asset conversion methods for increased efficiency and control.
	- Expanded the protocol's adaptability with the addition of multi-asset deposit and oracle functionalities, including support for Aave and Balancer flash loans.
- **Refactor**
	- Updated import statements across several contracts for better dependency management.
	- Replaced owner-only access control with a more flexible authorization mechanism in multiple contracts to enhance security and access control.
- **Tests**
	- Added integration tests for new authorization logic and complex contract functionalities, ensuring robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->